### PR TITLE
Feature: add runeword filter by runes, bugfix missing items in dropdown

### DIFF
--- a/src/pages/runewords/runewords.html
+++ b/src/pages/runewords/runewords.html
@@ -1,10 +1,10 @@
 <template>
     <h3 class="text-center my-4">
-        ${runewords.length} Runewords Found
+        ${filteredRunewords.length} Runewords Found
     </h3>
     <div class="container">
         <div class="row align-content-center justify-content-center text-center mb-5">
-            <div class="col-12 col-md-4">
+            <div class="col-12 col-md-4 col-lg-3">
                 <div class="au-select mb-2">
                     <moo-select
                             class="w-100"
@@ -15,7 +15,7 @@
                     ></moo-select>
                 </div>
             </div>
-            <div class="col-12 col-md-4">
+            <div class="col-12 col-md-4 col-lg-3">
                 <div class="au-select mb-2">
                     <moo-select
                             class="w-100"
@@ -26,13 +26,25 @@
                     ></moo-select>
                 </div>
             </div>
-            <div class="col-12 col-md-4">
-                <moo-text-field
-                        class="w-100"
-                        label="Search Runewords"
-                        type="text"
-                        value.bind="search"
-                ></moo-text-field>
+            <div class="col-12 col-md-4 col-lg-3">
+                <div class="mb-2">
+                    <moo-text-field
+                            class="w-100"
+                            label="Search Runewords"
+                            type="text"
+                            value.bind="search"
+                    ></moo-text-field>
+                </div>
+            </div>
+            <div class="col-12 col-md-4 col-lg-3">
+                <div class="mb-2">
+                    <moo-text-field
+                            class="w-100"
+                            label="Runes"
+                            type="text"
+                            value.bind="searchRunes"
+                    ></moo-text-field>
+                </div>
             </div>
         </div>
     </div>

--- a/src/pages/runewords/runewords.ts
+++ b/src/pages/runewords/runewords.ts
@@ -29,6 +29,7 @@ export class Runewords {
         { value: 'Sword', label: 'Sword' },
         { value: 'Axe', label: 'Axe' },
         { value: 'Amazon Bow', label: 'Amazon Bow' },
+        { value: 'Amazon Spear', label: 'Amazon Spear' },
         { value: 'Spear', label: 'Spear' },
         { value: 'Staff', label: 'Staff' },
         { value: 'Mace', label: 'Mace' },
@@ -38,7 +39,8 @@ export class Runewords {
         { value: 'Club', label: 'Club' },
         { value: 'Any Armor', label: 'Any Armor' },
         { value: 'Scepter', label: 'Scepter' },
-        { value: 'Druid Item', label: 'Druid Item' }
+        { value: 'Druid Item', label: 'Druid Item' },
+        { value: 'Necromancer Item', label: 'Necro Shield' },
     ];
 
     amounts = [

--- a/src/pages/runewords/runewords.ts
+++ b/src/pages/runewords/runewords.ts
@@ -7,6 +7,7 @@ export class Runewords {
     runewords = json;
 
     @bindable search: string;
+    @bindable searchRunes: string;
 
     private _debouncedSearchItem!: DebouncedFunction;
 
@@ -58,6 +59,13 @@ export class Runewords {
         this.updateList();
     }
 
+    @watch('searchRunes')
+    handleSearchRunesChanged() {
+        if (this._debouncedSearchItem) {
+            this._debouncedSearchItem();
+        }
+    }
+
     @watch('search')
     handleSearchChanged() {
         if (this._debouncedSearchItem) {
@@ -79,50 +87,70 @@ export class Runewords {
         }
     }
 
+    normalizeRuneName(name: string): string {
+        // Remove " Rune" suffix and trim any extra spaces
+        return name.replace(/ rune$/i, '').trim().toLowerCase();
+    }
+
     updateList() {
-        const found = [];
         let filteringRunewords = this.runewords;
+
+        // Type filtering
         if (this.selectedType) {
             filteringRunewords = filteringRunewords.filter((x) => {
                 for (const type of x.Types) {
-                    if (type.Index === this.selectedType) {
-                        return true;
-                    }
-                    if (type.Index === 'Merc Equip' && this.selectedType === 'Helm') {
+                    if (type.Index === this.selectedType || (type.Index === 'Merc Equip' && this.selectedType === 'Helm')) {
                         return true;
                     }
                 }
                 return false;
             });
         }
+
+        // Amount filtering
         if (this.selectedAmount) {
-            filteringRunewords = filteringRunewords.filter((x) => {
-                return x.Runes.length === this.selectedAmount;
-            });
+            filteringRunewords = filteringRunewords.filter((x) => x.Runes.length === this.selectedAmount);
         }
+
+        // Initialize found to apply both search filters together
+        let found = filteringRunewords;
+
+        // Regular search filter (by name, properties, types)
         if (this.search) {
-            for (const runeword of filteringRunewords) {
+            found = found.filter((runeword) => {
                 if (runeword.Name.toLowerCase().includes(this.search.toLowerCase())) {
-                    found.push(runeword);
-                    continue;
+                    return true;
                 }
                 for (const property of runeword.Properties) {
                     if (property.PropertyString.toLowerCase().includes(this.search.toLowerCase())) {
-                        found.push(runeword);
-                        break;
+                        return true;
                     }
                 }
                 for (const type of runeword.Types) {
                     if (type.Name.toLowerCase().includes(this.search.toLowerCase())) {
-                        found.push(runeword);
-                        break;
+                        return true;
                     }
                 }
-            }
-            this.filteredRunewords = found;
-        } else {
-            this.filteredRunewords = filteringRunewords;
+                return false;
+            });
         }
+
+        // Rune search filter
+        if (this.searchRunes) {
+            const inputRuneList = this.searchRunes.split(' ')
+                .map((rune) => rune.trim())
+                .filter((rune) => rune.length > 0);
+
+            found = found.filter((runeword) => {
+                const runewordRuneNames = runeword.Runes.map((rune) => this.normalizeRuneName(rune.Name));
+                return inputRuneList.every((inputRune) =>
+                    runewordRuneNames.includes(inputRune)
+                );
+            });
+        }
+
+        // Set the filtered runewords at the end
+        this.filteredRunewords = found;
     }
 
     removeRuneFromName(runeName) {


### PR DESCRIPTION
added a runeword filter by runes and added 2 missing item types in the runeword search dropdown. i checked it vs the json file. now all types are represented (except "Merc Equip" which doesnt seem to be useful by now)