### PR TITLE
Follow up to "search base item names" for sets

### DIFF
--- a/src/pages/sets/sets.ts
+++ b/src/pages/sets/sets.ts
@@ -86,6 +86,17 @@ export class Sets {
                             }
                         }
                     }
+                    if (this.class) {
+                        if (setItem.Equipment.Name.toLowerCase().includes(this.class?.toLowerCase())) {
+                            foundSets.push(set);
+                            continue loop1;
+                        }
+                    } else {
+                        if (setItem.Equipment.Name.toLowerCase().includes(this.search?.toLowerCase())) {
+                            foundSets.push(set);
+                            continue loop1;
+                        }
+                    }
                 }
             }
             this.sets = foundSets;


### PR DESCRIPTION
Similar to the previous implementation that allowed searching for base item names on the unique item page but for sets