### PR TITLE
Enhance Runewords rune filtering with inline multi-select chips and UX improvements

### DIFF
--- a/src/pages/runewords/runewords.html
+++ b/src/pages/runewords/runewords.html
@@ -81,14 +81,52 @@
                     </div>
                 </div>
 
-                <div class="w-full lg:w-60"
-                     data-help-text="Search for specific Runes. Uses (space) and + as AND. Uses , and | as OR. ex: El Eld|Hel Zod returns only Breath of the Dying and Starlight.">
+                <div class="w-full lg:w-60 lg:min-w-60 lg:max-w-60"
+                     data-help-text="Search and select one or more runes. Selected runes are shown as chips and can be removed with (x). A runeword must contain all selected runes.">
                     <div class="flex items-stretch">
-                        <div class="trailing-icon flex-1" data-icon="search">
-                            <input id="runesearch" type="text" class="select-base peer pr-12 w-full"
-                                   value.bind="searchRunes"
-                                   placeholder=" "/>
-                            <label for="runesearch" class="floating-label">Runes Only...</label>
+                        <div class="relative flex-1 min-w-0">
+                            <div class="select-base w-full min-h-[42px] h-auto flex flex-wrap items-center gap-1 py-1">
+                                <span
+                                    repeat.for="rune of selectedRunes"
+                                    class="group inline-flex shrink-0 items-center gap-1 rounded-lg border border-gray-600 bg-gray-900 px-2 py-0.5 text-base type-text"
+                                >
+                                    <span>${rune}</span>
+                                    <button
+                                        type="button"
+                                        click.trigger="removeRuneSelection(rune)"
+                                        title.bind="'Remove ' + rune"
+                                        class="inline-flex h-5 w-5 items-center justify-center rounded-full bg-red-500/15 border border-red-300/40 text-red-200 text-[13px] leading-none font-bold shadow-[inset_0_0_0_1px_rgba(255,255,255,0.05)] transition-all duration-150 group-hover:bg-red-500/30 group-hover:border-red-200/70 group-hover:text-red-100 group-hover:-translate-y-px"
+                                        aria-label.bind="'Remove ' + rune"
+                                    >×</button>
+                                </span>
+
+                                <input
+                                    id="runesearch"
+                                    type="text"
+                                    class="flex-1 min-w-[120px] bg-transparent border-0 outline-none ring-0 px-1 py-1 text-base type-text placeholder:text-gray-400"
+                                    value.bind="runeQuery"
+                                    change.trigger="addRuneSelection(runeQuery)"
+                                    keydown.trigger="handleRuneInputKeydown($event)"
+                                    list="rune-options"
+                                    autocomplete="off"
+                                    placeholder="Runes Only..."
+                                    aria-label="Runes Only"
+                                />
+
+                                <button
+                                    if.bind="selectedRunes.length >= 2"
+                                    type="button"
+                                    class="shrink-0 ml-auto inline-flex items-center rounded-lg border border-red-500/60 bg-red-500/10 px-2 py-0.5 text-base text-red-200 hover:bg-red-500/20 hover:border-red-400"
+                                    click.trigger="clearRuneSelections()"
+                                    title="Clear all selected runes"
+                                >
+                                    Clear
+                                </button>
+                            </div>
+
+                            <datalist id="rune-options">
+                                <option repeat.for="rune of runeOptions" value.bind="rune"></option>
+                            </datalist>
                         </div>
 
                         <!-- Mobile only info button -->

--- a/src/pages/runewords/runewords.ts
+++ b/src/pages/runewords/runewords.ts
@@ -39,10 +39,20 @@ export class Runewords {
     @bindable searchRunes: string;
     @bindable exclusiveType: boolean = false;
     @bindable hideVanilla: boolean = false;
+    @bindable runeQuery: string = '';
 
     private _debouncedSearchItem!: IDebouncedFunction;
+    private runeDisplayByKey: Map<string, string> = new Map<string, string>();
+    private readonly runeOrder: ReadonlyMap<string, number> = new Map<string, number>([
+        ['el', 1], ['eld', 2], ['tir', 3], ['nef', 4], ['eth', 5], ['ith', 6], ['tal', 7], ['ral', 8],
+        ['ort', 9], ['thul', 10], ['amn', 11], ['sol', 12], ['shael', 13], ['dol', 14], ['hel', 15],
+        ['io', 16], ['lum', 17], ['ko', 18], ['fal', 19], ['lem', 20], ['pul', 21], ['um', 22],
+        ['mal', 23], ['ist', 24], ['gul', 25], ['vex', 26], ['ohm', 27], ['lo', 28], ['sur', 29],
+        ['ber', 30], ['jah', 31], ['cham', 32], ['zod', 33],
+    ]);
 
     filteredRunewords: IRunewordData[] = [];
+    selectedRunes: string[] = [];
 
     // Centralized options, narrowed at runtime to types present in data
     types: ReadonlyArray<IFilterOption> = type_filtering_options.slice();
@@ -61,8 +71,144 @@ export class Runewords {
 
     selectedAmount: number | undefined;
 
+    get runeOptions(): string[] {
+        const query = this.normalizeRuneName(this.runeQuery || '');
+        const selected = new Set(
+            this.selectedRunes.map((r) => this.normalizeRuneName(r)),
+        );
+
+        return Array.from(this.runeDisplayByKey.entries())
+            .filter(([key, label]) => {
+                if (selected.has(key)) return false;
+                if (!query) return true;
+                return key.includes(query) || label.toLowerCase().includes(query);
+            })
+            .map(([, label]) => label)
+            .slice(0, 50);
+    }
+
+    private hydrateRuneCatalog() {
+        const catalog = new Map<string, string>();
+        for (const rw of this.runewords || []) {
+            for (const rune of rw?.Runes || []) {
+                const baseLabel = String(rune?.Name || '')
+                    .replace(/ rune$/i, '')
+                    .trim();
+                const key = this.normalizeRuneName(baseLabel);
+                if (!key) continue;
+                const rank = this.runeOrder.get(key);
+                const display = rank ? `${baseLabel} (${rank})` : baseLabel;
+                if (!catalog.has(key)) catalog.set(key, display);
+            }
+        }
+
+        this.runeDisplayByKey = new Map(
+            Array.from(catalog.entries()).sort(([aKey, aLabel], [bKey, bLabel]) => {
+                const aOrder = this.runeOrder.get(aKey) ?? Number.MAX_SAFE_INTEGER;
+                const bOrder = this.runeOrder.get(bKey) ?? Number.MAX_SAFE_INTEGER;
+                if (aOrder !== bOrder) return aOrder - bOrder;
+                return aLabel.localeCompare(bLabel);
+            }),
+        );
+    }
+
+    private syncRuneSearchFromSelections() {
+        this.searchRunes = this.selectedRunes.join(' + ');
+    }
+
+    private hydrateSelectedRunesFromSearch() {
+        const raw = (this.searchRunes || '').trim();
+        if (!raw) return;
+
+        const tokens = raw
+            .split(/[,\|\+\s]+/g)
+            .map((t) => this.normalizeRuneName(t))
+            .filter(Boolean);
+
+        const picked: string[] = [];
+        const seen = new Set<string>();
+
+        for (const key of tokens) {
+            if (seen.has(key)) continue;
+            const display = this.runeDisplayByKey.get(key);
+            if (!display) continue;
+            seen.add(key);
+            picked.push(display);
+        }
+
+        this.selectedRunes = picked;
+        if (!this.selectedRunes.length) this.runeQuery = raw;
+    }
+
+    addRuneSelection(rawInput: string) {
+        const text = String(rawInput || '').trim();
+        if (!text) return;
+
+        const parts = text
+            .split(/[,\|\+\s]+/g)
+            .map((p) => this.normalizeRuneName(p))
+            .filter(Boolean);
+
+        if (!parts.length) return;
+
+        const selectedKeys = new Set(
+            this.selectedRunes.map((r) => this.normalizeRuneName(r)),
+        );
+
+        for (const part of parts) {
+            if (selectedKeys.has(part)) continue;
+
+            let key = part;
+            if (!this.runeDisplayByKey.has(key)) {
+                const fuzzyMatches = Array.from(this.runeDisplayByKey.keys()).filter((k) =>
+                    k.includes(part),
+                );
+                if (fuzzyMatches.length !== 1) continue;
+                key = fuzzyMatches[0];
+            }
+
+            const display = this.runeDisplayByKey.get(key);
+            if (!display) continue;
+
+            selectedKeys.add(key);
+            this.selectedRunes.push(display);
+        }
+
+        this.runeQuery = '';
+        this.syncRuneSearchFromSelections();
+    }
+
+    removeRuneSelection(rune: string) {
+        const keyToRemove = this.normalizeRuneName(rune);
+        this.selectedRunes = this.selectedRunes.filter(
+            (r) => this.normalizeRuneName(r) !== keyToRemove,
+        );
+        this.syncRuneSearchFromSelections();
+    }
+
+    clearRuneSelections() {
+        this.selectedRunes = [];
+        this.syncRuneSearchFromSelections();
+    }
+
+    handleRuneInputKeydown(event: KeyboardEvent) {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            this.addRuneSelection(this.runeQuery);
+            return;
+        }
+
+        if (event.key === 'Backspace' && !String(this.runeQuery || '').trim()) {
+            const last = this.selectedRunes[this.selectedRunes.length - 1];
+            if (!last) return;
+            event.preventDefault();
+            this.removeRuneSelection(last);
+        }
+    }
+
     // Build options and hydrate filters from URL before controls render
     binding() {
+        this.hydrateRuneCatalog();
         const urlParams = new URLSearchParams(window.location.search);
 
         // Collect EXPLICIT base type names present in data (Runewords-only behavior)
@@ -137,6 +283,8 @@ export class Runewords {
         if (exactParam && !isBlankOrInvalid(exactParam)) {
             this.exclusiveType = exactParam === 'true';
         }
+
+        this.hydrateSelectedRunesFromSearch();
     }
 
     attached() {
@@ -205,9 +353,10 @@ export class Runewords {
     }
 
     normalizeRuneName(name: string): string {
-        // Remove " Rune" suffix and trim any extra spaces
+        // Remove " Rune" suffix and optional "(n)" rank, then normalize spaces.
         return name
             .replace(/ rune$/i, '')
+            .replace(/\(\s*\d+\s*\)/g, '')
             .trim()
             .toLowerCase();
     }
@@ -282,8 +431,22 @@ export class Runewords {
             });
         }
 
-        // Rune search filter (AND-of-OR groups)
-        if (this.searchRunes) {
+        // Rune selection filter (AND across selected rune chips)
+        if (this.selectedRunes.length) {
+            const selectedRuneTokens = this.selectedRunes.map((r) =>
+                this.normalizeRuneName(r),
+            );
+
+            found = found.filter((runeword) => {
+                const runewordRuneNames = (runeword.Runes ?? []).map((rune) =>
+                    this.normalizeRuneName(String(rune.Name)),
+                );
+                return selectedRuneTokens.every((token) =>
+                    runewordRuneNames.includes(token),
+                );
+            });
+        } else if (this.searchRunes) {
+            // Backward-compatible parser for old URL params that used custom AND/OR syntax.
             // Normalize operators:
             // - Space and '+' are AND (become spaces)
             // - ',' and '|' are OR (become '|')
@@ -336,6 +499,8 @@ export class Runewords {
     resetFilters() {
         this.search = '';
         this.searchRunes = '';
+        this.runeQuery = '';
+        this.selectedRunes = [];
         this.selectedType = '';
         this.selectedAmount = undefined;
         this.exclusiveType = false;

--- a/src/pages/runewords/runewords.ts
+++ b/src/pages/runewords/runewords.ts
@@ -206,7 +206,10 @@ export class Runewords {
         }
     }
 
-    // Build options and hydrate filters from URL before controls render
+    /**
+     * Aurelia lifecycle hook.
+     * Builds filter options from dataset contents and hydrates initial state from URL params.
+     */
     binding() {
         this.hydrateRuneCatalog();
         const urlParams = new URLSearchParams(window.location.search);
@@ -287,13 +290,20 @@ export class Runewords {
         this.hydrateSelectedRunesFromSearch();
     }
 
+    /**
+     * Aurelia lifecycle hook.
+     * Sets up debounced filtering once the view is attached, then performs first render.
+     */
     attached() {
         this._debouncedSearchItem = debounce(() => this.updateList(), 350);
         this.updateList();
         this.updateUrl();
     }
 
-    // Push current filters to URL
+    /**
+     * Writes the current filter state back into query params.
+     * Keeps links/share/bookmarks in sync with UI state.
+     */
     private updateUrl() {
         syncParamsToUrl({
             search: this.search,
@@ -305,24 +315,40 @@ export class Runewords {
         }, false);
     }
 
+    /**
+     * Reacts to rune search changes.
+     * Triggers debounced filtering and URL sync.
+     */
     @watch('searchRunes')
     handleSearchRunesChanged() {
         if (this._debouncedSearchItem) this._debouncedSearchItem();
         this.updateUrl();
     }
 
+    /**
+     * Reacts to free-text search changes.
+     * Triggers debounced filtering and URL sync.
+     */
     @watch('search')
     handleSearchChanged() {
         if (this._debouncedSearchItem) this._debouncedSearchItem();
         this.updateUrl();
     }
 
+    /**
+     * Reacts to item-type filter changes.
+     * Triggers debounced filtering and URL sync.
+     */
     @watch('selectedType')
     selectedTypeChanged() {
         if (this._debouncedSearchItem) this._debouncedSearchItem();
         this.updateUrl();
     }
 
+    /**
+     * Reacts to rune-count changes and normalizes select values to numbers.
+     * Triggers debounced filtering and URL sync.
+     */
     @watch('selectedAmount')
     selectedAmountChanged() {
         // Coerce from string to number when coming from <select>
@@ -340,18 +366,30 @@ export class Runewords {
         this.updateUrl();
     }
 
+    /**
+     * Reacts to exact-type toggle changes.
+     * Triggers debounced filtering and URL sync.
+     */
     @watch('exclusiveType')
     handleExclusiveTypeChanged() {
         if (this._debouncedSearchItem) this._debouncedSearchItem();
         this.updateUrl();
     }
 
+    /**
+     * Reacts to hide-vanilla toggle changes.
+     * Triggers debounced filtering and URL sync.
+     */
     @watch('hideVanilla')
     handleHideVanillaChanged() {
         if (this._debouncedSearchItem) this._debouncedSearchItem();
         this.updateUrl();
     }
 
+    /**
+     * Normalizes rune names for matching.
+     * Example: "El Rune" -> "el".
+     */
     normalizeRuneName(name: string): string {
         // Remove " Rune" suffix and optional "(n)" rank, then normalize spaces.
         return name
@@ -361,6 +399,10 @@ export class Runewords {
             .toLowerCase();
     }
 
+    /**
+     * Main filtering pipeline.
+     * Applies type, socket count, text, rune, and vanilla filters in sequence.
+     */
     updateList() {
         let filteringRunewords: IRunewordData[] = this.runewords;
 
@@ -495,7 +537,9 @@ export class Runewords {
         this.filteredRunewords = found;
     }
 
-    // Reset all filters and refresh URL/list
+    /**
+     * Clears all active filters and refreshes both result list and URL state.
+     */
     resetFilters() {
         this.search = '';
         this.searchRunes = '';


### PR DESCRIPTION
## Summary
This PR upgrades the Runewords page rune filter from a plain text input to a more intuitive inline multi-select chip experience. Users can now search and select runes directly, remove individual selections with a dedicated close icon, and quickly clear all selections when multiple runes are chosen.

## What Changed
- Reworked `Runes Only` into an inline chip-based tag input.
- Added searchable rune suggestions with numbered labels (example: `El (1)`).
- Selecting a rune adds it as a chip in the same field.
- Added per-chip remove control (`×`) with improved styling/hover behavior.
- Only the `×` removes a chip (clicking chip text no longer removes).
- Added keyboard behavior:
  - `Enter` adds selected/typed rune.
  - `Backspace` on empty input removes last selected rune.
- Added conditional `Clear` button (visible when 2+ runes selected) to remove all selections.
- Kept URL/query-param sync for filters.
- Added readability comments in runewords filtering functions for maintainability.

## Behavior / UX Notes
- Rune chips are displayed inline with the input and wrap as needed.
- Filtering remains **AND** across selected runes (a runeword must contain all selected runes).
- Legacy rune query parsing remains supported for backward compatibility.

## Files Changed
- `src/pages/runewords/runewords.html`
- `src/pages/runewords/runewords.ts`