### PR TITLE
Add search to dropdowns

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -239,6 +239,7 @@ const TooltipManager = (() => {
 
     const onEnter: EventListener = () => {
         if (Date.now() < (rec.suppressedUntil || 0)) return;
+        if (trigger.closest('[data-tooltip-disabled]') || trigger.hasAttribute('data-tooltip-disabled')) return;
         clearIdle(rec);
         rec.idleTimer = window.setTimeout(() => {
             // Remove our hidden state before showing; if the show fails, restore it
@@ -253,6 +254,7 @@ const TooltipManager = (() => {
     };
     const onMove: EventListener = () => {
         if (Date.now() < (rec.suppressedUntil || 0)) return;
+        if (trigger.closest('[data-tooltip-disabled]') || trigger.hasAttribute('data-tooltip-disabled')) return;
         // Any cursor movement while hovering resets the idle timer until stable for idleMs
         clearIdle(rec);
         rec.idleTimer = window.setTimeout(() => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -163,21 +163,10 @@ const TooltipManager = (() => {
         ).toLowerCase();
         // Only accept safe values we use (top/bottom). Could be extended to left/right if desired.
         const allowed: Record<string, true> = { top: true, bottom: true };
-        // Default / fallback
-        let placement: 'top' | 'bottom' = allowed[overridePlacement]
+        // Default / fallback – always prefer 'top' so tooltips don't cover the search area.
+        const placement: 'top' | 'bottom' = allowed[overridePlacement]
             ? (overridePlacement as 'top' | 'bottom')
             : 'top';
-        try {
-            if (!allowed[overridePlacement]) {
-                const rect = trigger.getBoundingClientRect();
-                const vh = window.innerHeight || document.documentElement.clientHeight;
-                const spaceAbove = rect.top;
-                const spaceBelow = vh - rect.bottom;
-                placement = spaceAbove >= spaceBelow ? 'top' : 'bottom';
-            }
-        } catch {
-            /* default to top */
-        }
 
         // Resolve the required idle (no-move) delay before showing, in ms.
         const resolveIdleMs = (): number => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -163,10 +163,21 @@ const TooltipManager = (() => {
         ).toLowerCase();
         // Only accept safe values we use (top/bottom). Could be extended to left/right if desired.
         const allowed: Record<string, true> = { top: true, bottom: true };
-        // Default / fallback – always prefer 'top' so tooltips don't cover the search area.
-        const placement: 'top' | 'bottom' = allowed[overridePlacement]
+        // Default / fallback
+        let placement: 'top' | 'bottom' = allowed[overridePlacement]
             ? (overridePlacement as 'top' | 'bottom')
             : 'top';
+        try {
+            if (!allowed[overridePlacement]) {
+                const rect = trigger.getBoundingClientRect();
+                const vh = window.innerHeight || document.documentElement.clientHeight;
+                const spaceAbove = rect.top;
+                const spaceBelow = vh - rect.bottom;
+                placement = spaceAbove >= spaceBelow ? 'top' : 'bottom';
+            }
+        } catch {
+            /* default to top */
+        }
 
         // Resolve the required idle (no-move) delay before showing, in ms.
         const resolveIdleMs = (): number => {

--- a/src/pages/affixes/affixes.html
+++ b/src/pages/affixes/affixes.html
@@ -13,61 +13,51 @@
         <div class="w-full m-auto px-5 py-2">
             <div class="flex flex-wrap justify-center items-start gap-2">
 
-                <div class="w-full lg:w-auto lg:min-w-60" data-help-text="Choose between prefixes, suffixes, or both.">
-                    <div class="flex items-stretch">
-                        <div class="relative flex-1">
-                            <select id="ptype" class="select-base peer" value.bind="selectedPType">
-                                <option repeat.for="opt of pTypeOptions" value.bind="opt.value"> ${opt.label}</option>
-                            </select>
-                            <label for="ptype" class="floating-label">Select Affix Type</label>
-                        </div>
-                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="ptype">
-                            <span class="mso">info</span>
-                            <span class="sr-only">More info about Affix Type filter</span>
-                        </button>
-                    </div>
-                </div>
+                <searchable-select id="ptype"
+                                   class="w-full lg:w-auto lg:min-w-60"
+                                   data-help-text="Choose between prefixes, suffixes, or both."
+                                   value.bind="selectedPType"
+                                   options.bind="pTypeOptions"
+                                   label="Select Affix Type">
+                    <button au-slot="after" type="button" class="m-info-button" aria-expanded="false" data-info-for="ptype">
+                        <span class="mso">info</span>
+                        <span class="sr-only">More info about Affix Type filter</span>
+                    </button>
+                </searchable-select>
 
-                <div class="w-full lg:w-auto lg:min-w-60" data-help-text="Filter by property group (e.g., Damage, Defense, Utility). Note: Still WIP some may be incorrect.">
-                    <div class="flex items-stretch">
-                        <div class="relative flex-1">
-                            <select id="desc" class="select-base peer" value.bind="selectedGroupDescription">
-                                <option repeat.for="opt of groupOptions" value.bind="opt.value"> ${opt.label}</option>
-                            </select>
-                            <label for="desc" class="floating-label">
-                                Select Property Type</label>
-                        </div>
-                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="desc">
-                            <span class="mso">info</span>
-                            <span class="sr-only">More info about Property Type filter</span>
-                        </button>
-                    </div>
-                </div>
+                <searchable-select id="desc"
+                                   class="w-full lg:w-auto lg:min-w-60"
+                                   data-help-text="Filter by property group (e.g., Damage, Defense, Utility). Note: Still WIP some may be incorrect."
+                                   value.bind="selectedGroupDescription"
+                                   options.bind="groupOptions"
+                                   label="Select Property Type">
+                    <button au-slot="after" type="button" class="m-info-button" aria-expanded="false" data-info-for="desc">
+                        <span class="mso">info</span>
+                        <span class="sr-only">More info about Property Type filter</span>
+                    </button>
+                </searchable-select>
 
-                <div class="w-full lg:w-auto lg:min-w-60 flex flex-nowrap" data-help-text="Filter by base item type. Toggle ‘Exact’ to remove variants.">
-                    <div class="w-full relative">
-                        <select id="itype" class="select-base-exact peer" value.bind="selectedType">
-                            <option repeat.for="opt of types"
-                                    value.bind="opt.id">${opt.label}
-                            </option>
-                        </select>
-                        <label for="itype" class="floating-label">Select Item Type</label>
-                    </div>
-                    <div class="flex items-center">
-                        <button
-                                type="button"
+                <searchable-select id="itype"
+                                   class="w-full lg:w-auto lg:min-w-60"
+                                   data-help-text="Filter by base item type. Toggle ‘Exact’ to remove variants."
+                                   value.bind="selectedType"
+                                   options.bind="types"
+                                   label="Select Item Type"
+                                   exact.bind="true">
+                    <div au-slot="after" class="flex items-stretch">
+                        <button type="button"
                                 class="exact-button"
                                 aria-pressed.bind="exclusiveType"
                                 click.trigger="exclusiveType = !exclusiveType">
                             <span class="exact-indicator"></span>
                             Exact
                         </button>
+                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="itype">
+                            <span class="mso">info</span>
+                            <span class="sr-only">More info about Item Type filter</span>
+                        </button>
                     </div>
-                    <button type="button" class="m-info-button" aria-expanded="false" data-info-for="itype">
-                        <span class="mso">info</span>
-                        <span class="sr-only">More info about Item Type filter</span>
-                    </button>
-                </div>
+                </searchable-select>
 
                 <div class="w-full lg:w-60" data-help-text="Search across all fields. Attempts exact match. Seperate with '+' for AND match. Seperate with ',' or '|' for OR match. ex. 'fire skill damage+enemy fire' finds items with only both tokens. 'fire skill damage,enemy fire' finds items with either token.">
                     <div class="flex items-stretch">
@@ -84,22 +74,20 @@
                 </div>
 
                 <div class="w-full flex flex-nowrap gap-2 lg:w-auto lg:min-w-60" data-help-text="Filter by required level range. The min and max values will update each other if they overlap.">
-                    <div class="w-full relative">
-                        <select id="minrlvl" class="select-base peer" value.bind="minRequiredLevel">
-                            <option repeat.for="opt of rLevelOptions" value.bind="opt.value">${opt.label}</option>
-                        </select>
-                        <label for="minrlvl" class="floating-label">Min RLv</label>
-                    </div>
-                    <div class="w-full relative">
-                        <select id="maxrlvl" class="select-base peer" value.bind="maxRequiredLevel">
-                            <option repeat.for="opt of rLevelOptions" value.bind="opt.value">${opt.label}</option>
-                        </select>
-                        <label for="maxrlvl" class="floating-label">Max RLv</label>
-                    </div>
-                    <button type="button" class="m-info-button ml-0!" aria-expanded="false" data-info-for="minrlvl">
-                        <span class="mso">info</span>
-                        <span class="sr-only">More info about Required Level filters</span>
-                    </button>
+                    <searchable-select id="minrlvl"
+                                       value.bind="minRequiredLevel"
+                                       options.bind="rLevelOptions"
+                                       label="Min RLv">
+                    </searchable-select>
+                    <searchable-select id="maxrlvl"
+                                       value.bind="maxRequiredLevel"
+                                       options.bind="rLevelOptions"
+                                       label="Max RLv">
+                        <button au-slot="after" type="button" class="m-info-button ml-0!" aria-expanded="false" data-info-for="minrlvl">
+                            <span class="mso">info</span>
+                            <span class="sr-only">More info about Required Level filters</span>
+                        </button>
+                    </searchable-select>
                 </div>
 
                 <div class="w-full lg:w-auto lg:min-w-35" data-help-text="Reset all filters to default.">

--- a/src/pages/affixes/affixes.html
+++ b/src/pages/affixes/affixes.html
@@ -13,17 +13,20 @@
         <div class="w-full m-auto px-5 py-2">
             <div class="flex flex-wrap justify-center items-start gap-2">
 
-                <searchable-select id="ptype"
-                                   class="w-full lg:w-auto lg:min-w-60"
-                                   data-help-text="Choose between prefixes, suffixes, or both."
-                                   value.bind="selectedPType"
-                                   options.bind="pTypeOptions"
-                                   label="Select Affix Type">
-                    <button au-slot="after" type="button" class="m-info-button" aria-expanded="false" data-info-for="ptype">
-                        <span class="mso">info</span>
-                        <span class="sr-only">More info about Affix Type filter</span>
-                    </button>
-                </searchable-select>
+                <div class="w-full lg:w-auto lg:min-w-45" data-help-text="Choose between prefixes, suffixes, or both.">
+                    <div class="flex items-stretch">
+                        <div class="relative flex-1">
+                            <select id="ptype" class="select-base peer" value.bind="selectedPType">
+                                <option repeat.for="opt of pTypeOptions" value.bind="opt.value"> ${opt.label}</option>
+                            </select>
+                            <label for="ptype" class="floating-label">Select Affix Type</label>
+                        </div>
+                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="ptype">
+                            <span class="mso">info</span>
+                            <span class="sr-only">More info about Affix Type filter</span>
+                        </button>
+                    </div>
+                </div>
 
                 <searchable-select id="desc"
                                    class="w-full lg:w-auto lg:min-w-60"
@@ -38,7 +41,7 @@
                 </searchable-select>
 
                 <searchable-select id="itype"
-                                   class="w-full lg:w-auto lg:min-w-60"
+                                   class="w-full lg:w-auto lg:min-w-75"
                                    data-help-text="Filter by base item type. Toggle ‘Exact’ to remove variants."
                                    value.bind="selectedType"
                                    options.bind="types"
@@ -74,20 +77,22 @@
                 </div>
 
                 <div class="w-full flex flex-nowrap gap-2 lg:w-auto lg:min-w-60" data-help-text="Filter by required level range. The min and max values will update each other if they overlap.">
-                    <searchable-select id="minrlvl"
-                                       value.bind="minRequiredLevel"
-                                       options.bind="rLevelOptions"
-                                       label="Min RLv">
-                    </searchable-select>
-                    <searchable-select id="maxrlvl"
-                                       value.bind="maxRequiredLevel"
-                                       options.bind="rLevelOptions"
-                                       label="Max RLv">
-                        <button au-slot="after" type="button" class="m-info-button ml-0!" aria-expanded="false" data-info-for="minrlvl">
-                            <span class="mso">info</span>
-                            <span class="sr-only">More info about Required Level filters</span>
-                        </button>
-                    </searchable-select>
+                    <div class="w-full relative">
+                        <select id="minrlvl" class="select-base peer" value.bind="minRequiredLevel">
+                            <option repeat.for="opt of rLevelOptions" value.bind="opt.value">${opt.label}</option>
+                        </select>
+                        <label for="minrlvl" class="floating-label">Min RLv</label>
+                    </div>
+                    <div class="w-full relative">
+                        <select id="maxrlvl" class="select-base peer" value.bind="maxRequiredLevel">
+                            <option repeat.for="opt of rLevelOptions" value.bind="opt.value">${opt.label}</option>
+                        </select>
+                        <label for="maxrlvl" class="floating-label">Max RLv</label>
+                    </div>
+                    <button type="button" class="m-info-button ml-0!" aria-expanded="false" data-info-for="minrlvl">
+                        <span class="mso">info</span>
+                        <span class="sr-only">More info about Required Level filters</span>
+                    </button>
                 </div>
 
                 <div class="w-full lg:w-auto lg:min-w-35" data-help-text="Reset all filters to default.">

--- a/src/pages/affixes/affixes.ts
+++ b/src/pages/affixes/affixes.ts
@@ -39,7 +39,7 @@ interface IAffixItem {
     RequiredLevel?: number | string;
     Properties?: Array<{
         PropertyString?: string;
-        'group-properties'?: Record<string, any[]>;
+        'group-properties'?: Record<string, Array<{ PropertyString?: string }>>;
         pickmode?: number;
         Chance?: number;
     }>;
@@ -387,15 +387,15 @@ export class Affixes {
             if (typeof minOpt === 'number' && rl < minOpt) return false;
             if (typeof maxOpt === 'number' && rl > maxOpt) return false;
 
-    // Text search (tokenized AND; search across Name, Properties, and Types only). ETypes are excluded.
+            // Text search (tokenized AND; search across Name, Properties, and Types only). ETypes are excluded.
             if (hasQuery) {
                 const groupStrings: string[] = [];
                 (a?.Properties || []).forEach((p) => {
                     if (p['group-properties']) {
                         Object.values(p['group-properties']).forEach((pool) => {
-                            pool.forEach((affix: any) => {
+                            pool.forEach((affix) => {
                                 if (affix.PropertyString)
-                                    groupStrings.push(affix.PropertyString);
+                                    groupStrings.push(String(affix.PropertyString));
                             });
                         });
                     }

--- a/src/pages/bases/bases.html
+++ b/src/pages/bases/bases.html
@@ -12,30 +12,42 @@
             <div class="flex flex-wrap justify-center items-start gap-2">
 
                 <!-- Category selector: - (both), Armors, Weapons -->
-                <searchable-select id="category"
-                                   class="w-full lg:w-auto lg:min-w-60"
-                                   data-help-text="Choose between armors, weapons, or both."
-                                   value.bind="selectedCategory"
-                                   options.bind="categoryOptions"
-                                   label="Select Category"
-                                   change.trigger="handleCategoryChange()">
-                    <button au-slot="after" type="button" class="m-info-button" aria-expanded="false" data-info-for="category">
-                        <span class="mso">info</span>
-                        <span class="sr-only">More info about Category filter</span>
-                    </button>
-                </searchable-select>
+                <div class="w-full lg:w-auto lg:min-w-60" data-help-text="Choose between armors, weapons, or both.">
+                    <div class="flex items-stretch">
+                        <div class="relative flex-1">
+                            <select id="category" class="select-base peer" value.bind="selectedCategory"
+                                    change.trigger="handleCategoryChange()">
+                                <option repeat.for="opt of categoryOptions" value.bind="opt.value">${opt.label}</option>
+                            </select>
+                            <label for="category" class="floating-label">Select Category</label>
+                        </div>
+                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="category">
+                            <span class="mso">info</span>
+                            <span class="sr-only">More info about Category filter</span>
+                        </button>
+                    </div>
+                </div>
 
-                <searchable-select id="sockets"
-                                   class="w-full lg:w-auto lg:min-w-60"
-                                   data-help-text="Filter by the max possible sockets on the base."
-                                   value.bind="selectedSockets"
-                                   options.bind="socketOptions"
-                                   label="Select Sockets">
-                    <button au-slot="after" type="button" class="m-info-button" aria-expanded="false" data-info-for="sockets">
-                        <span class="mso">info</span>
-                        <span class="sr-only">More info about Sockets filter</span>
-                    </button>
-                </searchable-select>
+                <div class="w-full lg:w-auto lg:min-w-60"
+                     data-help-text="Filter by the max possible sockets on the base.">
+                    <div class="flex items-stretch">
+                        <div class="relative flex-1">
+                            <select id="sockets" class="select-base peer" value.bind="selectedSockets">
+                                <option repeat.for="opt of socketOptions" if.bind="opt.value === ''" value="">
+                                    ${opt.label}
+                                </option>
+                                <option repeat.for="opt of socketOptions" if.bind="opt.value !== ''"
+                                        model.bind="opt.value">${opt.label}
+                                </option>
+                            </select>
+                            <label for="sockets" class="floating-label">Select Sockets</label>
+                        </div>
+                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="sockets">
+                            <span class="mso">info</span>
+                            <span class="sr-only">More info about Sockets filter</span>
+                        </button>
+                    </div>
+                </div>
 
                 <searchable-select id="itype"
                                    class="w-full lg:w-auto lg:min-w-60"
@@ -49,17 +61,21 @@
                     </button>
                 </searchable-select>
 
-                <searchable-select id="tier"
-                                   class="w-full lg:w-auto lg:min-w-60"
-                                   data-help-text="Filter by the base tier. With none selected, the page defaults to sticking NXE of a base group with each other."
-                                   value.bind="selectedTier"
-                                   options.bind="tierOptions"
-                                   label="Select Tier">
-                    <button au-slot="after" type="button" class="m-info-button" aria-expanded="false" data-info-for="tier">
-                        <span class="mso">info</span>
-                        <span class="sr-only">More info about Tier filter</span>
-                    </button>
-                </searchable-select>
+                <div class="w-full lg:w-auto lg:min-w-60"
+                     data-help-text="Filter by the base tier. With none selected, the page defaults to sticking NXE of a base group with each other.">
+                    <div class="flex items-stretch">
+                        <div class="relative flex-1">
+                            <select id="tier" class="select-base peer" value.bind="selectedTier">
+                                <option repeat.for="opt of tierOptions" value.bind="opt.value">${opt.label}</option>
+                            </select>
+                            <label for="tier" class="floating-label">Select Tier</label>
+                        </div>
+                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="tier">
+                            <span class="mso">info</span>
+                            <span class="sr-only">More info about Tier filter</span>
+                        </button>
+                    </div>
+                </div>
 
                 <div class="w-full lg:w-60"
                      data-help-text="Search across all fields. Attempts exact match. Seperate with '+' for AND match. Seperate with ',' or '|' for OR match. ex. 'fire skill damage+enemy fire' finds items with only both tokens. 'fire skill damage,enemy fire' finds items with either token.">

--- a/src/pages/bases/bases.html
+++ b/src/pages/bases/bases.html
@@ -12,75 +12,54 @@
             <div class="flex flex-wrap justify-center items-start gap-2">
 
                 <!-- Category selector: - (both), Armors, Weapons -->
-                <div class="w-full lg:w-auto lg:min-w-60" data-help-text="Choose between armors, weapons, or both.">
-                    <div class="flex items-stretch">
-                        <div class="relative flex-1">
-                            <select id="category" class="select-base peer" value.bind="selectedCategory"
-                                    change.trigger="handleCategoryChange()">
-                                <option repeat.for="opt of categoryOptions" value.bind="opt.value">${opt.label}</option>
-                            </select>
-                            <label for="category" class="floating-label">Select Category</label>
-                        </div>
-                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="category">
-                            <span class="mso">info</span>
-                            <span class="sr-only">More info about Category filter</span>
-                        </button>
-                    </div>
-                </div>
+                <searchable-select id="category"
+                                   class="w-full lg:w-auto lg:min-w-60"
+                                   data-help-text="Choose between armors, weapons, or both."
+                                   value.bind="selectedCategory"
+                                   options.bind="categoryOptions"
+                                   label="Select Category"
+                                   change.trigger="handleCategoryChange()">
+                    <button au-slot="after" type="button" class="m-info-button" aria-expanded="false" data-info-for="category">
+                        <span class="mso">info</span>
+                        <span class="sr-only">More info about Category filter</span>
+                    </button>
+                </searchable-select>
 
-                <div class="w-full lg:w-auto lg:min-w-60"
-                     data-help-text="Filter by the max possible sockets on the base.">
-                    <div class="flex items-stretch">
-                        <div class="relative flex-1">
-                            <select id="sockets" class="select-base peer" value.bind="selectedSockets">
-                                <option repeat.for="opt of socketOptions" if.bind="opt.value === ''" value="">
-                                    ${opt.label}
-                                </option>
-                                <option repeat.for="opt of socketOptions" if.bind="opt.value !== ''"
-                                        model.bind="opt.value">${opt.label}
-                                </option>
-                            </select>
-                            <label for="sockets" class="floating-label">Select Sockets</label>
-                        </div>
-                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="sockets">
-                            <span class="mso">info</span>
-                            <span class="sr-only">More info about Sockets filter</span>
-                        </button>
-                    </div>
-                </div>
+                <searchable-select id="sockets"
+                                   class="w-full lg:w-auto lg:min-w-60"
+                                   data-help-text="Filter by the max possible sockets on the base."
+                                   value.bind="selectedSockets"
+                                   options.bind="socketOptions"
+                                   label="Select Sockets">
+                    <button au-slot="after" type="button" class="m-info-button" aria-expanded="false" data-info-for="sockets">
+                        <span class="mso">info</span>
+                        <span class="sr-only">More info about Sockets filter</span>
+                    </button>
+                </searchable-select>
 
-                <div class="w-full lg:w-auto lg:min-w-60" data-help-text="Filter by the base item type.">
-                    <div class="flex items-stretch">
-                        <div class="relative flex-1">
-                            <select id="itype" class="select-base peer" value.bind="selectedType">
-                                <option repeat.for="opt of types"
-                                        value.bind="opt.id">${opt.label}
-                                </option>
-                            </select>
-                            <label for="itype" class="floating-label">Select Item Type</label>
-                        </div>
-                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="itype">
-                            <span class="mso">info</span>
-                            <span class="sr-only">More info about Item Type filter</span>
-                        </button>
-                    </div>
-                </div>
+                <searchable-select id="itype"
+                                   class="w-full lg:w-auto lg:min-w-60"
+                                   data-help-text="Filter by the base item type."
+                                   value.bind="selectedType"
+                                   options.bind="types"
+                                   label="Select Item Type">
+                    <button au-slot="after" type="button" class="m-info-button" aria-expanded="false" data-info-for="itype">
+                        <span class="mso">info</span>
+                        <span class="sr-only">More info about Item Type filter</span>
+                    </button>
+                </searchable-select>
 
-                <div class="w-full lg:w-auto lg:min-w-60"
-                     data-help-text="Filter by the base tier. With none selected, the page defaults to sticking NXE of a base group with each other.">
-                    <div class="flex items-stretch">
-                        <div class="relative flex-1">
-                            <select id="tier" class="select-base peer" value.bind="selectedTier">
-                                <option repeat.for="opt of tierOptions" value.bind="opt.value">${opt.label}</option>
-                            </select>
-                            <label for="tier" class="floating-label">Select Tier</label>
-                        </div>
-                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="tier">
-                            <span class="mso">info</span>
-                            <span class="sr-only">More info about Tier filter</span>
-                        </button>
-                    </div>
-                </div>
+                <searchable-select id="tier"
+                                   class="w-full lg:w-auto lg:min-w-60"
+                                   data-help-text="Filter by the base tier. With none selected, the page defaults to sticking NXE of a base group with each other."
+                                   value.bind="selectedTier"
+                                   options.bind="tierOptions"
+                                   label="Select Tier">
+                    <button au-slot="after" type="button" class="m-info-button" aria-expanded="false" data-info-for="tier">
+                        <span class="mso">info</span>
+                        <span class="sr-only">More info about Tier filter</span>
+                    </button>
+                </searchable-select>
 
                 <div class="w-full lg:w-60"
                      data-help-text="Search across all fields. Attempts exact match. Seperate with '+' for AND match. Seperate with ',' or '|' for OR match. ex. 'fire skill damage+enemy fire' finds items with only both tokens. 'fire skill damage,enemy fire' finds items with either token.">

--- a/src/pages/bases/bases.ts
+++ b/src/pages/bases/bases.ts
@@ -348,7 +348,7 @@ export class Bases {
             members.push(i);
         }
 
-        const tierOrder = { 'Normal': 0, 'Exceptional': 1, 'Elite': 2 };
+        const tierOrder: Record<string, number> = { 'Normal': 0, 'Exceptional': 1, 'Elite': 2 };
 
         const groups = Array.from(typeMap.entries())
             .map(([typeName, familyMap]) => {

--- a/src/pages/cube-recipes/cube-recipes.html
+++ b/src/pages/cube-recipes/cube-recipes.html
@@ -19,17 +19,21 @@
                     </button>
                 </searchable-select>
 
-                <searchable-select id="ficlass"
-                                   class="w-full lg:w-auto lg:min-w-60"
-                                   data-help-text="Filter recipes by character class. note: These are all the same for each class but grant class-specific skills on use."
-                                   value.bind="selectedClass"
-                                   options.bind="classOptions"
-                                   label="Select Class">
-                    <button au-slot="after" type="button" class="m-info-button" aria-expanded="false" data-info-for="ficlass">
-                        <span class="mso">info</span>
-                        <span class="sr-only">More info about Class filter</span>
-                    </button>
-                </searchable-select>
+                <div class="w-full lg:w-auto lg:min-w-60"
+                     data-help-text="Filter recipes by character class. note: These are all the same for each class but grant class-specific skills on use.">
+                    <div class="flex items-stretch">
+                        <div class="relative flex-1">
+                            <select id="ficlass" class="select-base peer" value.bind="selectedClass">
+                                <option repeat.for="opt of classOptions" value.bind="opt.value">${opt.label}</option>
+                            </select>
+                            <label for="ficlass" class="floating-label">Select Class</label>
+                        </div>
+                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="ficlass">
+                            <span class="mso">info</span>
+                            <span class="sr-only">More info about Class filter</span>
+                        </button>
+                    </div>
+                </div>
 
                 <div class="w-full lg:w-60"
                      data-help-text="Search across all fields. Attempts exact match. Seperate with '+' for AND match. Seperate with ',' or '|' for OR match. ex. 'fire skill damage+enemy fire' finds items with only both tokens. 'fire skill damage,enemy fire' finds items with either token.">

--- a/src/pages/cube-recipes/cube-recipes.html
+++ b/src/pages/cube-recipes/cube-recipes.html
@@ -7,37 +7,29 @@
         <div class="w-full m-auto px-5 py-2">
             <div class="flex flex-wrap justify-center items-start gap-2">
 
-                <div class="w-full lg:w-auto lg:min-w-60"
-                     data-help-text="Filter recipes by type (reroll, upgrade, craft, etc.).">
-                    <div class="flex items-stretch">
-                        <div class="relative flex-1">
-                            <select id="notesel" class="select-base peer" value.bind="selectedNote">
-                                <option repeat.for="opt of noteOptions" value.bind="opt.value">${opt.label}</option>
-                            </select>
-                            <label for="notesel" class="floating-label">Select Recipe Type</label>
-                        </div>
-                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="notesel">
-                            <span class="mso">info</span>
-                            <span class="sr-only">More info about Recipe Type filter</span>
-                        </button>
-                    </div>
-                </div>
+                <searchable-select id="notesel"
+                                   class="w-full lg:w-auto lg:min-w-60"
+                                   data-help-text="Filter recipes by type (reroll, upgrade, craft, etc.)."
+                                   value.bind="selectedNote"
+                                   options.bind="noteOptions"
+                                   label="Select Recipe Type">
+                    <button au-slot="after" type="button" class="m-info-button" aria-expanded="false" data-info-for="notesel">
+                        <span class="mso">info</span>
+                        <span class="sr-only">More info about Recipe Type filter</span>
+                    </button>
+                </searchable-select>
 
-                <div class="w-full lg:w-auto lg:min-w-60"
-                     data-help-text="Filter recipes by character class. note: These are all the same for each class but grant class-specific skills on use.">
-                    <div class="flex items-stretch">
-                        <div class="relative flex-1">
-                            <select id="ficlass" class="select-base peer" value.bind="selectedClass">
-                                <option repeat.for="opt of classOptions" value.bind="opt.value">${opt.label}</option>
-                            </select>
-                            <label for="ficlass" class="floating-label">Select Class</label>
-                        </div>
-                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="ficlass">
-                            <span class="mso">info</span>
-                            <span class="sr-only">More info about Class filter</span>
-                        </button>
-                    </div>
-                </div>
+                <searchable-select id="ficlass"
+                                   class="w-full lg:w-auto lg:min-w-60"
+                                   data-help-text="Filter recipes by character class. note: These are all the same for each class but grant class-specific skills on use."
+                                   value.bind="selectedClass"
+                                   options.bind="classOptions"
+                                   label="Select Class">
+                    <button au-slot="after" type="button" class="m-info-button" aria-expanded="false" data-info-for="ficlass">
+                        <span class="mso">info</span>
+                        <span class="sr-only">More info about Class filter</span>
+                    </button>
+                </searchable-select>
 
                 <div class="w-full lg:w-60"
                      data-help-text="Search across all fields. Attempts exact match. Seperate with '+' for AND match. Seperate with ',' or '|' for OR match. ex. 'fire skill damage+enemy fire' finds items with only both tokens. 'fire skill damage,enemy fire' finds items with either token.">

--- a/src/pages/grail/grail.html
+++ b/src/pages/grail/grail.html
@@ -64,29 +64,35 @@
         <div class="w-full m-auto px-5 py-2">
             <div class="flex flex-wrap justify-center items-start gap-2">
 
-                <searchable-select id="category"
-                                   class="w-full lg:w-auto lg:min-w-60"
-                                   data-help-text="Choose the Grail category list."
-                                   value.bind="selectedCategory"
-                                   options.bind="categories"
-                                   label="Select Category">
-                    <button au-slot="after" type="button" class="m-info-button" aria-expanded="false" data-info-for="category">
-                        <span class="mso">info</span>
-                        <span class="sr-only">More info about Category filter</span>
-                    </button>
-                </searchable-select>
+                <div class="w-full lg:w-auto lg:min-w-60" data-help-text="Choose the Grail category list.">
+                    <div class="flex items-stretch">
+                        <div class="relative flex-1">
+                            <select id="category" class="select-base peer" value.bind="selectedCategory">
+                                <option repeat.for="opt of categories" value.bind="opt.value">${opt.label}</option>
+                            </select>
+                            <label for="category" class="floating-label">Select Category</label>
+                        </div>
+                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="category">
+                            <span class="mso">info</span>
+                            <span class="sr-only">More info about Category filter</span>
+                        </button>
+                    </div>
+                </div>
 
-                <searchable-select id="ficlass"
-                                   class="w-full lg:w-auto lg:min-w-60"
-                                   data-help-text="Filter by character class."
-                                   value.bind="selectedClass"
-                                   options.bind="classes"
-                                   label="Select Class">
-                    <button au-slot="after" type="button" class="m-info-button" aria-expanded="false" data-info-for="ficlass">
-                        <span class="mso">info</span>
-                        <span class="sr-only">More info about Class filter</span>
-                    </button>
-                </searchable-select>
+                <div class="w-full lg:w-auto lg:min-w-60" data-help-text="Filter by character class.">
+                    <div class="flex items-stretch">
+                        <div class="relative flex-1">
+                            <select id="ficlass" class="select-base peer" value.bind="selectedClass">
+                                <option repeat.for="opt of classes" value.bind="opt.value">${opt.label}</option>
+                            </select>
+                            <label for="ficlass" class="floating-label">Select Class</label>
+                        </div>
+                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="ficlass">
+                            <span class="mso">info</span>
+                            <span class="sr-only">More info about Class filter</span>
+                        </button>
+                    </div>
+                </div>
 
                 <searchable-select id="itype"
                                    class="w-full lg:w-auto lg:min-w-60"

--- a/src/pages/grail/grail.html
+++ b/src/pages/grail/grail.html
@@ -64,69 +64,54 @@
         <div class="w-full m-auto px-5 py-2">
             <div class="flex flex-wrap justify-center items-start gap-2">
 
-                <div class="w-full lg:w-auto lg:min-w-60" data-help-text="Choose the Grail category list.">
-                    <div class="flex items-stretch">
-                        <div class="relative flex-1">
-                            <select id="category" class="select-base peer" value.bind="selectedCategory">
-                                <option repeat.for="opt of categories" value.bind="opt.value">${opt.label}</option>
-                            </select>
-                            <label for="category" class="floating-label">Select Category</label>
-                        </div>
-                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="category">
-                            <span class="mso">info</span>
-                            <span class="sr-only">More info about Category filter</span>
-                        </button>
-                    </div>
-                </div>
+                <searchable-select id="category"
+                                   class="w-full lg:w-auto lg:min-w-60"
+                                   data-help-text="Choose the Grail category list."
+                                   value.bind="selectedCategory"
+                                   options.bind="categories"
+                                   label="Select Category">
+                    <button au-slot="after" type="button" class="m-info-button" aria-expanded="false" data-info-for="category">
+                        <span class="mso">info</span>
+                        <span class="sr-only">More info about Category filter</span>
+                    </button>
+                </searchable-select>
 
-                <div class="w-full lg:w-auto lg:min-w-60" data-help-text="Filter by character class.">
-                    <div class="flex items-stretch">
-                        <div class="relative flex-1">
-                            <select id="ficlass" class="select-base peer" value.bind="selectedClass">
-                                <option repeat.for="opt of classes" value.bind="opt.value">${opt.label}</option>
-                            </select>
-                            <label for="ficlass" class="floating-label">Select Class</label>
-                        </div>
-                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="ficlass">
-                            <span class="mso">info</span>
-                            <span class="sr-only">More info about Class filter</span>
-                        </button>
-                    </div>
-                </div>
+                <searchable-select id="ficlass"
+                                   class="w-full lg:w-auto lg:min-w-60"
+                                   data-help-text="Filter by character class."
+                                   value.bind="selectedClass"
+                                   options.bind="classes"
+                                   label="Select Class">
+                    <button au-slot="after" type="button" class="m-info-button" aria-expanded="false" data-info-for="ficlass">
+                        <span class="mso">info</span>
+                        <span class="sr-only">More info about Class filter</span>
+                    </button>
+                </searchable-select>
 
-                <div class="w-full lg:w-auto lg:min-w-60" data-help-text="Filter by base item type, looser than other pages due to Grail.">
-                    <div class="flex items-stretch">
-                        <div class="relative flex-1">
-                            <select id="itype" class="select-base peer" value.bind="selectedTypeBase">
-                                <option repeat.for="opt of types"
-                                        value.bind="opt.id">${opt.label}
-                                </option>
-                            </select>
-                            <label for="itype" class="floating-label">Select Type</label>
-                        </div>
-                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="itype">
-                            <span class="mso">info</span>
-                            <span class="sr-only">More info about Type filter</span>
-                        </button>
-                    </div>
-                </div>
+                <searchable-select id="itype"
+                                   class="w-full lg:w-auto lg:min-w-60"
+                                   data-help-text="Filter by base item type, looser than other pages due to Grail."
+                                   value.bind="selectedTypeBase"
+                                   options.bind="types"
+                                   label="Select Type">
+                    <button au-slot="after" type="button" class="m-info-button" aria-expanded="false" data-info-for="itype">
+                        <span class="mso">info</span>
+                        <span class="sr-only">More info about Type filter</span>
+                    </button>
+                </searchable-select>
 
-                <div class="w-full lg:w-auto lg:min-w-60" data-help-text="Filter to a specific equipment for the selected item type, disabled if one isn't selected.">
-                    <div class="flex items-stretch">
-                        <div class="relative flex-1">
-                            <select id="eqsel" class="select-base peer"
-                                    value.bind="selectedEquipmentName"
-                                    disabled.bind="selectedCategory === 'runewords' || !selectedTypeBase">
-                                <option repeat.for="opt of equipmentNames" value.bind="opt.id">${opt.name}</option>
-                            </select>
-                            <label for="eqsel" class="floating-label">Select Equipment</label>
-                        </div>
-                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="eqsel">
-                            <span class="mso">info</span>
-                            <span class="sr-only">More info about Equipment filter</span>
-                        </button>
-                    </div>
-                </div>
+                <searchable-select id="eqsel"
+                                   class="w-full lg:w-auto lg:min-w-60"
+                                   data-help-text="Filter to a specific equipment for the selected item type, disabled if one isn't selected."
+                                   value.bind="selectedEquipmentName"
+                                   options.bind="equipmentNames"
+                                   label="Select Equipment"
+                                   disabled.bind="selectedCategory === 'runewords' || !selectedTypeBase">
+                    <button au-slot="after" type="button" class="m-info-button" aria-expanded="false" data-info-for="eqsel">
+                        <span class="mso">info</span>
+                        <span class="sr-only">More info about Equipment filter</span>
+                    </button>
+                </searchable-select>
 
                 <div class="w-full lg:w-60" data-help-text="Search across all fields. Attempts exact match. Seperate with '+' for AND match. Seperate with ',' or '|' for OR match. ex. 'fire skill damage+enemy fire' finds items with only both tokens. 'fire skill damage,enemy fire' finds items with either token.">
                     <div class="flex items-stretch">

--- a/src/pages/runewords/runewords.html
+++ b/src/pages/runewords/runewords.html
@@ -7,60 +7,42 @@
         <div class="w-full m-auto px-5 py-2">
             <div class="flex flex-wrap justify-center items-start gap-2">
 
-                <div class="w-full lg:w-auto lg:min-w-40"
-                     data-help-text="Filter by number of runes required. This amount is exact.">
-                    <div class="flex items-stretch">
-                        <div class="relative flex-1">
-                            <select id="runecount" class="select-base peer" value.bind="selectedAmount">
-                                <option repeat.for="opt of amounts" if.bind="opt.value === ''" value="">${opt.label}
-                                </option>
-                                <option repeat.for="opt of amounts" if.bind="opt.value !== ''" model.bind="opt.value">
-                                    ${opt.label}
-                                </option>
-                            </select>
-                            <label for="runecount" class="floating-label">Rune Count</label>
-                        </div>
-                        <!-- Mobile-only info button -->
-                        <button type="button"
-                                class="m-info-button"
-                                aria-expanded="false" data-info-for="runecount"
-                        >
-                            <span class="mso">info</span>
-                            <span class="sr-only">More info about Item Type filter</span>
-                        </button>
-                    </div>
-                </div>
+                <searchable-select id="runecount"
+                                   class="w-full lg:w-auto lg:min-w-40"
+                                   data-help-text="Filter by number of runes required. This amount is exact."
+                                   value.bind="selectedAmount"
+                                   options.bind="amounts"
+                                   label="Rune Count">
+                    <button au-slot="after" type="button" class="m-info-button" aria-expanded="false" data-info-for="runecount">
+                        <span class="mso">info</span>
+                        <span class="sr-only">More info about Item Type filter</span>
+                    </button>
+                </searchable-select>
 
-                <div class="w-full lg:w-auto lg:min-w-70 flex flex-nowrap items-stretch"
-                     data-help-text="Filter by base item type. Toggle ‘Exact’ to remove variants."
-                >
-                    <div class="relative flex-1">
-                        <select id="itype" class="select-base-exact peer" value.bind="selectedType">
-                            <option repeat.for="opt of types"
-                                    value.bind="opt.id">${opt.label}
-                            </option>
-                        </select>
-                        <label for="itype" class="floating-label">Select Item Type</label>
-                    </div>
-                    <div class="flex items-center">
-                        <button
-                                type="button"
+                <searchable-select id="itype"
+                                   class="w-full lg:w-auto lg:min-w-70"
+                                   data-help-text="Filter by base item type. Toggle ‘Exact’ to remove variants."
+                                   value.bind="selectedType"
+                                   options.bind="types"
+                                   label="Select Item Type"
+                                   exact.bind="true">
+                    <div au-slot="after" class="flex items-stretch">
+                        <button type="button"
                                 class="exact-button"
                                 aria-pressed.bind="exclusiveType"
                                 click.trigger="exclusiveType = !exclusiveType">
                             <span class="exact-indicator"></span>
                             Exact
                         </button>
+                        <!-- Mobile-only info button -->
+                        <button type="button"
+                                class="m-info-button"
+                                aria-expanded="false" data-info-for="itype">
+                            <span class="mso">info</span>
+                            <span class="sr-only">More info about Item Type filter</span>
+                        </button>
                     </div>
-                    <!-- Mobile-only info button -->
-                    <button type="button"
-                            class="m-info-button"
-                            aria-expanded="false" data-info-for="itype"
-                    >
-                        <span class="mso">info</span>
-                        <span class="sr-only">More info about Item Type filter</span>
-                    </button>
-                </div>
+                </searchable-select>
 
                 <div class="w-full lg:w-60"
                      data-help-text="Search across all fields. Attempts exact match. Seperate with '+' for AND match. Seperate with ',' or '|' for OR match. ex. 'fire skill damage+enemy fire' finds items with only both tokens. 'fire skill damage,enemy fire' finds items with either token.">

--- a/src/pages/runewords/runewords.html
+++ b/src/pages/runewords/runewords.html
@@ -7,17 +7,20 @@
         <div class="w-full m-auto px-5 py-2">
             <div class="flex flex-wrap justify-center items-start gap-2">
 
-                <searchable-select id="runecount"
-                                   class="w-full lg:w-auto lg:min-w-40"
-                                   data-help-text="Filter by number of runes required. This amount is exact."
-                                   value.bind="selectedAmount"
-                                   options.bind="amounts"
-                                   label="Rune Count">
-                    <button au-slot="after" type="button" class="m-info-button" aria-expanded="false" data-info-for="runecount">
-                        <span class="mso">info</span>
-                        <span class="sr-only">More info about Item Type filter</span>
-                    </button>
-                </searchable-select>
+                <div class="w-full lg:w-auto lg:min-w-40" data-help-text="Filter by number of runes required. This amount is exact.">
+                    <div class="flex items-stretch">
+                        <div class="relative flex-1">
+                            <select id="runecount" class="select-base peer" value.bind="selectedAmount">
+                                <option repeat.for="opt of amounts" value.bind="opt.value">${opt.label}</option>
+                            </select>
+                            <label for="runecount" class="floating-label">Rune Count</label>
+                        </div>
+                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="runecount">
+                            <span class="mso">info</span>
+                            <span class="sr-only">More info about Item Type filter</span>
+                        </button>
+                    </div>
+                </div>
 
                 <searchable-select id="itype"
                                    class="w-full lg:w-auto lg:min-w-70"

--- a/src/pages/runewords/runewords.ts
+++ b/src/pages/runewords/runewords.ts
@@ -41,6 +41,13 @@ export class Runewords {
     filteredRunewords: IRunewordData[] = [];
     private _searchStrings = new Map<IRunewordData, string>();
 
+    @bindable search: string = '';
+    @bindable searchRunes: string = '';
+    @bindable exclusiveType: boolean = false;
+    @bindable hideVanilla: boolean = false;
+
+    private _debouncedSearchItem!: IDebouncedFunction;
+
     // Centralized options, narrowed at runtime to types present in data
     types: ReadonlyArray<IFilterOption> = type_filtering_options.slice();
 

--- a/src/pages/sets/sets.html
+++ b/src/pages/sets/sets.html
@@ -11,56 +11,42 @@
         <div class="w-full m-auto px-5 py-2">
             <div class="flex flex-wrap justify-center items-start gap-2">
 
-                <div class="w-full lg:w-auto lg:min-w-60"
-                     data-help-text="Filter by character class, sets match as full set if one is found.">
-                    <div class="flex items-stretch">
-                        <div class="relative flex-1">
-                            <select id="ficlass" class="select-base peer" value.bind="selectedClass">
-                                <option repeat.for="opt of classes" value.bind="opt.value">${opt.label}</option>
-                            </select>
-                            <label for="ficlass" class="floating-label">Select Class</label>
-                        </div>
-                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="ficlass">
-                            <span class="mso">info</span>
-                            <span class="sr-only">More info about Class filter</span>
-                        </button>
-                    </div>
-                </div>
+                <searchable-select id="ficlass"
+                                   class="w-full lg:w-auto lg:min-w-60"
+                                   data-help-text="Filter by character class, sets match as full set if one is found."
+                                   value.bind="selectedClass"
+                                   options.bind="classes"
+                                   label="Select Class">
+                    <button au-slot="after" type="button" class="m-info-button" aria-expanded="false" data-info-for="ficlass">
+                        <span class="mso">info</span>
+                        <span class="sr-only">More info about Class filter</span>
+                    </button>
+                </searchable-select>
 
-                <div class="w-full lg:w-auto lg:min-w-60"
-                     data-help-text="Filter by base item type, sets match as full set if one is found.">
-                    <div class="flex items-stretch">
-                        <div class="relative flex-1">
-                            <select id="itype" class="select-base peer" value.bind="selectedType">
-                                <option repeat.for="opt of types"
-                                        value.bind="opt.id">${opt.label}
-                                </option>
-                            </select>
-                            <label for="itype" class="floating-label">Select Item Type</label>
-                        </div>
-                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="itype">
-                            <span class="mso">info</span>
-                            <span class="sr-only">More info about Item Type filter</span>
-                        </button>
-                    </div>
-                </div>
+                <searchable-select id="itype"
+                                   class="w-full lg:w-auto lg:min-w-60"
+                                   data-help-text="Filter by base item type, sets match as full set if one is found."
+                                   value.bind="selectedType"
+                                   options.bind="types"
+                                   label="Select Item Type">
+                    <button au-slot="after" type="button" class="m-info-button" aria-expanded="false" data-info-for="itype">
+                        <span class="mso">info</span>
+                        <span class="sr-only">More info about Item Type filter</span>
+                    </button>
+                </searchable-select>
 
-                <div class="w-full lg:w-auto lg:min-w-60"
-                     data-help-text="Filter to a specific equipment for the selected type, disabled if one isn't selected.">
-                    <div class="flex items-stretch">
-                        <div class="relative flex-1">
-                            <select id="eqname" class="select-base peer" value.bind="selectedEquipmentName"
-                                    disabled.bind="!selectedType">
-                                <option repeat.for="opt of equipmentNames" value.bind="opt.value">${opt.label}</option>
-                            </select>
-                            <label for="eqname" class="floating-label">Select Equipment</label>
-                        </div>
-                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="eqname">
-                            <span class="mso">info</span>
-                            <span class="sr-only">More info about Equipment filter</span>
-                        </button>
-                    </div>
-                </div>
+                <searchable-select id="eqname"
+                                   class="w-full lg:w-auto lg:min-w-60"
+                                   data-help-text="Filter to a specific equipment for the selected type, disabled if one isn't selected."
+                                   value.bind="selectedEquipmentName"
+                                   options.bind="equipmentNames"
+                                   label="Select Equipment"
+                                   disabled.bind="!selectedType">
+                    <button au-slot="after" type="button" class="m-info-button" aria-expanded="false" data-info-for="eqname">
+                        <span class="mso">info</span>
+                        <span class="sr-only">More info about Equipment filter</span>
+                    </button>
+                </searchable-select>
 
                 <div class="w-full lg:w-60"
                      data-help-text="Search across all fields, sets match as full set if one is found. Uses (space) as an 'AND' modifier. ex: Typing sorc skill mana will return items with only all 3 words.">

--- a/src/pages/sets/sets.html
+++ b/src/pages/sets/sets.html
@@ -11,17 +11,21 @@
         <div class="w-full m-auto px-5 py-2">
             <div class="flex flex-wrap justify-center items-start gap-2">
 
-                <searchable-select id="ficlass"
-                                   class="w-full lg:w-auto lg:min-w-60"
-                                   data-help-text="Filter by character class, sets match as full set if one is found."
-                                   value.bind="selectedClass"
-                                   options.bind="classes"
-                                   label="Select Class">
-                    <button au-slot="after" type="button" class="m-info-button" aria-expanded="false" data-info-for="ficlass">
-                        <span class="mso">info</span>
-                        <span class="sr-only">More info about Class filter</span>
-                    </button>
-                </searchable-select>
+                <div class="w-full lg:w-auto lg:min-w-60"
+                     data-help-text="Filter by character class, sets match as full set if one is found.">
+                    <div class="flex items-stretch">
+                        <div class="relative flex-1">
+                            <select id="ficlass" class="select-base peer" value.bind="selectedClass">
+                                <option repeat.for="opt of classes" value.bind="opt.value">${opt.label}</option>
+                            </select>
+                            <label for="ficlass" class="floating-label">Select Class</label>
+                        </div>
+                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="ficlass">
+                            <span class="mso">info</span>
+                            <span class="sr-only">More info about Class filter</span>
+                        </button>
+                    </div>
+                </div>
 
                 <searchable-select id="itype"
                                    class="w-full lg:w-auto lg:min-w-60"

--- a/src/pages/sets/sets.ts
+++ b/src/pages/sets/sets.ts
@@ -219,7 +219,7 @@ export class Sets {
                 if (allowedTypeSet) {
                     const hasMatch = (set.SetItems ?? []).some((si) => {
                         const base = getChainForTypeNameReadonly(si?.Type ?? '')[0] || (si?.Type ?? '');
-                        return allowedTypeSet!.has(base);
+                        return allowedTypeSet.has(base);
                     });
                     if (!hasMatch) return false;
                 }
@@ -277,6 +277,7 @@ export class Sets {
                 });
             }
         } catch (e) {
+            // eslint-disable-next-line no-console
             console.error(e);
             this.sets = this.allSets;
         }

--- a/src/pages/uniques/uniques.html
+++ b/src/pages/uniques/uniques.html
@@ -11,53 +11,42 @@
         <div class="w-full m-auto px-5 py-2">
             <div class="flex flex-wrap justify-center items-start gap-2">
 
-                <div class="w-full lg:w-auto lg:min-w-60" data-help-text="Filter by character class.">
-                    <div class="flex items-stretch">
-                        <div class="relative flex-1">
-                            <select id="ficlass" class="select-base peer" value.bind="selectedClass">
-                                <option repeat.for="opt of classes" value.bind="opt.value">${opt.label}</option>
-                            </select>
-                            <label for="ficlass" class="floating-label">Select Class</label>
-                        </div>
-                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="ficlass">
-                            <span class="mso">info</span>
-                            <span class="sr-only">More info about Class filter</span>
-                        </button>
-                    </div>
-                </div>
+                <searchable-select id="ficlass"
+                                   class="w-full lg:w-auto lg:min-w-60"
+                                   data-help-text="Filter by character class."
+                                   value.bind="selectedClass"
+                                   options.bind="classes"
+                                   label="Select Class">
+                    <button au-slot="after" type="button" class="m-info-button" aria-expanded="false" data-info-for="ficlass">
+                        <span class="mso">info</span>
+                        <span class="sr-only">More info about Class filter</span>
+                    </button>
+                </searchable-select>
 
-                <div class="w-full lg:w-auto lg:min-w-60" data-help-text="Filter by base item type, only includes class specific variants on generic types.">
-                    <div class="flex items-stretch">
-                        <div class="relative flex-1">
-                            <select id="itype" class="select-base peer" value.bind="selectedType">
-                                <option repeat.for="opt of types"
-                                        value.bind="opt.id">${opt.label}
-                                </option>
-                            </select>
-                            <label for="itype" class="floating-label">Select Item Type</label>
-                        </div>
-                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="itype">
-                            <span class="mso">info</span>
-                            <span class="sr-only">More info about Item Type filter</span>
-                        </button>
-                    </div>
-                </div>
+                <searchable-select id="itype"
+                                   class="w-full lg:w-auto lg:min-w-60"
+                                   data-help-text="Filter by base item type, only includes class specific variants on generic types."
+                                   value.bind="selectedType"
+                                   options.bind="types"
+                                   label="Select Item Type">
+                    <button au-slot="after" type="button" class="m-info-button" aria-expanded="false" data-info-for="itype">
+                        <span class="mso">info</span>
+                        <span class="sr-only">More info about Item Type filter</span>
+                    </button>
+                </searchable-select>
 
-                <div class="w-full lg:w-auto lg:min-w-60" data-help-text="Filter to a specific equipment for the selected item type, disabled if one isn't selected.">
-                    <div class="flex items-stretch">
-                        <div class="relative flex-1">
-                            <select id="eqsel" class="select-base peer" value.bind="selectedEquipmentName"
-                                    disabled.bind="!selectedType">
-                                <option repeat.for="opt of equipmentNames" value.bind="opt.value">${opt.label}</option>
-                            </select>
-                            <label for="eqsel" class="floating-label">Select Equipment</label>
-                        </div>
-                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="eqsel">
-                            <span class="mso">info</span>
-                            <span class="sr-only">More info about Equipment filter</span>
-                        </button>
-                    </div>
-                </div>
+                <searchable-select id="eqsel"
+                                   class="w-full lg:w-auto lg:min-w-60"
+                                   data-help-text="Filter to a specific equipment for the selected item type, disabled if one isn't selected."
+                                   value.bind="selectedEquipmentName"
+                                   options.bind="equipmentNames"
+                                   label="Select Equipment"
+                                   disabled.bind="!selectedType">
+                    <button au-slot="after" type="button" class="m-info-button" aria-expanded="false" data-info-for="eqsel">
+                        <span class="mso">info</span>
+                        <span class="sr-only">More info about Equipment filter</span>
+                    </button>
+                </searchable-select>
 
                 <div class="w-full lg:w-60" data-help-text="Search across all fields. Attempts exact match. Seperate with '+' for AND match. Seperate with ',' or '|' for OR match. ex. 'fire skill damage+enemy fire' finds items with only both tokens. 'fire skill damage,enemy fire' finds items with either token.">
                     <div class="flex items-stretch">

--- a/src/pages/uniques/uniques.html
+++ b/src/pages/uniques/uniques.html
@@ -11,17 +11,20 @@
         <div class="w-full m-auto px-5 py-2">
             <div class="flex flex-wrap justify-center items-start gap-2">
 
-                <searchable-select id="ficlass"
-                                   class="w-full lg:w-auto lg:min-w-60"
-                                   data-help-text="Filter by character class."
-                                   value.bind="selectedClass"
-                                   options.bind="classes"
-                                   label="Select Class">
-                    <button au-slot="after" type="button" class="m-info-button" aria-expanded="false" data-info-for="ficlass">
-                        <span class="mso">info</span>
-                        <span class="sr-only">More info about Class filter</span>
-                    </button>
-                </searchable-select>
+                <div class="w-full lg:w-auto lg:min-w-60" data-help-text="Filter by character class.">
+                    <div class="flex items-stretch">
+                        <div class="relative flex-1">
+                            <select id="ficlass" class="select-base peer" value.bind="selectedClass">
+                                <option repeat.for="opt of classes" value.bind="opt.value">${opt.label}</option>
+                            </select>
+                            <label for="ficlass" class="floating-label">Select Class</label>
+                        </div>
+                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="ficlass">
+                            <span class="mso">info</span>
+                            <span class="sr-only">More info about Class filter</span>
+                        </button>
+                    </div>
+                </div>
 
                 <searchable-select id="itype"
                                    class="w-full lg:w-auto lg:min-w-60"

--- a/src/resources/elements/index.ts
+++ b/src/resources/elements/index.ts
@@ -1,1 +1,2 @@
 export * from './search-area';
+export * from './searchable-select';

--- a/src/resources/elements/searchable-select/index.ts
+++ b/src/resources/elements/searchable-select/index.ts
@@ -1,0 +1,1 @@
+﻿export * from './searchable-select';

--- a/src/resources/elements/searchable-select/searchable-select.html
+++ b/src/resources/elements/searchable-select/searchable-select.html
@@ -1,0 +1,58 @@
+﻿<template class="block relative searchable-select-container ${isOpen ? 'z-30' : 'z-0'}">
+    <div class="relative flex items-stretch">
+        <div class="relative flex-1">
+            <!-- The main "select" trigger button -->
+            <button type="button"
+                    id.bind="id"
+                    class="${exact ? 'select-base-exact' : 'select-base'} peer text-left flex items-center justify-between cursor-pointer ${disabled ? 'opacity-50 cursor-not-allowed' : ''} ${ (!disabled && value !== '' && value !== undefined) ? 'ring ring-gray-400' : '' }"
+                    click.trigger="toggle($event)"
+                    disabled.bind="disabled"
+                    aria-haspopup="listbox"
+                    aria-expanded.bind="isOpen.toString()">
+                <span class="truncate">${displayLabel || '&nbsp;'}</span>
+                <span class="mso ml-2 transition-transform ${isOpen ? 'rotate-180' : ''}">arrow_downward</span>
+            </button>
+
+            <!-- Floating Label -->
+            <label if.bind="label"
+                   for.bind="id"
+                   class="floating-label ${disabled ? 'bg-gray-900 text-gray-500' : ''} ${ (isOpen || (value !== '' && value !== undefined)) ? 'bg-transparent top-1 -translate-y-2/5 scale-75' : '' }">
+                ${label}
+            </label>
+        </div>
+        <au-slot name="after"></au-slot>
+    </div>
+
+    <!-- Dropdown Panel -->
+    <div if.bind="isOpen"
+         class="absolute z-50 w-full mt-1 bg-gray-800 border border-gray-600 rounded-lg shadow-xl overflow-hidden min-w-[200px]"
+         click.trigger="panelClick($event)">
+        <!-- Search Box -->
+        <div class="p-2 border-b border-gray-600 bg-gray-900">
+            <div class="relative">
+                <input type="text"
+                       value.bind="searchText"
+                       class="w-full bg-gray-800 border border-gray-600 text-base type-text px-3 py-1.5 rounded outline-none focus:ring-1 focus:ring-gray-400"
+                       placeholder="Search..."
+                       ref="searchInput"
+                       keydown.trigger="$event.key === 'Escape' && (isOpen = false)">
+                <span class="mso absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none">search</span>
+            </div>
+        </div>
+
+        <!-- Options List -->
+        <ul class="max-h-60 overflow-y-auto py-1" role="listbox">
+            <li repeat.for="opt of filteredOptions"
+                class="px-3 py-2 cursor-pointer hover:bg-gray-700 type-text flex items-center justify-between ${String(getOptValue(opt)) === String(value) ? 'bg-gray-700' : ''}"
+                click.trigger="selectOption(opt, $event)"
+                role="option"
+                aria-selected.bind="(String(getOptValue(opt)) === String(value)).toString()">
+                <span>${getOptLabel(opt)}</span>
+                <span if.bind="String(getOptValue(opt)) === String(value)" class="mso text-lime-500">check</span>
+            </li>
+            <li if.bind="filteredOptions.length === 0" class="px-3 py-4 text-center text-gray-500 italic">
+                No results found
+            </li>
+        </ul>
+    </div>
+</template>

--- a/src/resources/elements/searchable-select/searchable-select.html
+++ b/src/resources/elements/searchable-select/searchable-select.html
@@ -35,7 +35,7 @@
                        class="w-full bg-gray-800 border border-gray-600 text-base type-text px-3 py-1.5 rounded outline-none focus:ring-1 focus:ring-gray-400"
                        placeholder="Search..."
                        ref="searchInput"
-                       keydown.trigger="$event.key === 'Escape' && (isOpen = false)">
+                       keydown.trigger="$event.key === 'Escape' && close()">
                 <span class="mso absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none">search</span>
             </div>
         </div>

--- a/src/resources/elements/searchable-select/searchable-select.html
+++ b/src/resources/elements/searchable-select/searchable-select.html
@@ -16,7 +16,7 @@
             <!-- Floating Label -->
             <label if.bind="label"
                    for.bind="id"
-                   class="floating-label ${disabled ? 'bg-gray-900 text-gray-500' : ''} ${ (isOpen || (value !== '' && value !== undefined)) ? 'bg-transparent top-1 -translate-y-2/5 scale-75' : '' }">
+                   class="floating-label ${disabled ? 'bg-transparent!' : ''} ${ (isOpen || (value !== '' && value !== undefined)) ? 'bg-transparent top-1 -translate-y-2/5 scale-75' : '' }">
                 ${label}
             </label>
         </div>

--- a/src/resources/elements/searchable-select/searchable-select.ts
+++ b/src/resources/elements/searchable-select/searchable-select.ts
@@ -1,0 +1,83 @@
+﻿import { bindable, BindingMode, ICustomElementViewModel, INode, resolve } from 'aurelia';
+
+export interface ISelectOption {
+    id?: string | number;
+    value?: string | number;
+    label?: string;
+    name?: string;
+}
+
+export class SearchableSelect implements ICustomElementViewModel {
+    @bindable({ mode: BindingMode.twoWay }) value: any;
+    @bindable options: ISelectOption[] = [];
+    @bindable label: string = '';
+    @bindable id: string = '';
+    @bindable disabled: boolean = false;
+    @bindable exact: boolean = false;
+
+    searchText: string = '';
+    isOpen: boolean = false;
+    searchInput: HTMLInputElement | null = null;
+
+    private element: HTMLElement = resolve(INode) as HTMLElement;
+    private _boundDocClick: ((ev: MouseEvent) => void) | null = null;
+
+    get filteredOptions() {
+        if (!this.searchText) return this.options;
+        const search = this.searchText.toLowerCase();
+        return this.options.filter(opt => this.getOptLabel(opt).toLowerCase().includes(search));
+    }
+
+    get selectedOption() {
+        return this.options.find(opt => String(this.getOptValue(opt)) === String(this.value));
+    }
+
+    get displayLabel() {
+        return this.selectedOption ? this.getOptLabel(this.selectedOption) : '';
+    }
+
+    attached() {
+        this._boundDocClick = (ev: MouseEvent) => {
+            if (this.isOpen && !this.element.contains(ev.target as Node)) {
+                this.isOpen = false;
+            }
+        };
+        // Bubble phase: internal clicks that stopPropagation won't reach here
+        document.addEventListener('click', this._boundDocClick, false);
+    }
+
+    detaching() {
+        if (this._boundDocClick) {
+            document.removeEventListener('click', this._boundDocClick, false);
+            this._boundDocClick = null;
+        }
+    }
+
+    toggle(ev: Event) {
+        if (this.disabled) return;
+        this.isOpen = !this.isOpen;
+        if (this.isOpen) {
+            this.searchText = '';
+            // Use a microtask so the DOM (if.bind) renders the input first
+            Promise.resolve().then(() => this.searchInput?.focus());
+        }
+    }
+
+    selectOption(opt: ISelectOption, ev: Event) {
+        ev.stopPropagation();
+        this.value = this.getOptValue(opt);
+        this.isOpen = false;
+    }
+
+    panelClick(ev: Event) {
+        ev.stopPropagation();
+    }
+
+    getOptValue(opt: ISelectOption): any {
+        return opt.id !== undefined ? opt.id : opt.value;
+    }
+
+    getOptLabel(opt: ISelectOption): string {
+        return opt.label ?? opt.name ?? '';
+    }
+}

--- a/src/resources/elements/searchable-select/searchable-select.ts
+++ b/src/resources/elements/searchable-select/searchable-select.ts
@@ -40,6 +40,7 @@ export class SearchableSelect implements ICustomElementViewModel {
         this._boundDocClick = (ev: MouseEvent) => {
             if (this.isOpen && !this.element.contains(ev.target as Node)) {
                 this.isOpen = false;
+                this._syncTooltipDisabled();
             }
         };
         // Bubble phase: internal clicks that stopPropagation won't reach here
@@ -56,6 +57,7 @@ export class SearchableSelect implements ICustomElementViewModel {
     toggle(ev: Event) {
         if (this.disabled) return;
         this.isOpen = !this.isOpen;
+        this._syncTooltipDisabled();
         if (this.isOpen) {
             this.searchText = '';
             // Use a microtask so the DOM (if.bind) renders the input first
@@ -67,6 +69,12 @@ export class SearchableSelect implements ICustomElementViewModel {
         ev.stopPropagation();
         this.value = this.getOptValue(opt);
         this.isOpen = false;
+        this._syncTooltipDisabled();
+    }
+
+    close() {
+        this.isOpen = false;
+        this._syncTooltipDisabled();
     }
 
     panelClick(ev: Event) {
@@ -79,5 +87,14 @@ export class SearchableSelect implements ICustomElementViewModel {
 
     getOptLabel(opt: ISelectOption): string {
         return opt.label ?? opt.name ?? '';
+    }
+
+    /** Suppress ancestor/self tooltips while the dropdown is open. */
+    private _syncTooltipDisabled() {
+        if (this.isOpen) {
+            this.element.setAttribute('data-tooltip-disabled', '');
+        } else {
+            this.element.removeAttribute('data-tooltip-disabled');
+        }
     }
 }

--- a/src/resources/elements/searchable-select/searchable-select.ts
+++ b/src/resources/elements/searchable-select/searchable-select.ts
@@ -8,7 +8,7 @@ export interface ISelectOption {
 }
 
 export class SearchableSelect implements ICustomElementViewModel {
-    @bindable({ mode: BindingMode.twoWay }) value: any;
+    @bindable({ mode: BindingMode.twoWay }) value: string | number | undefined;
     @bindable options: ISelectOption[] = [];
     @bindable label: string = '';
     @bindable id: string = '';
@@ -54,14 +54,15 @@ export class SearchableSelect implements ICustomElementViewModel {
         }
     }
 
-    toggle(ev: Event) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    toggle(_ev: Event) {
         if (this.disabled) return;
         this.isOpen = !this.isOpen;
         this._syncTooltipDisabled();
         if (this.isOpen) {
             this.searchText = '';
             // Use a microtask so the DOM (if.bind) renders the input first
-            Promise.resolve().then(() => this.searchInput?.focus());
+            void Promise.resolve().then(() => this.searchInput?.focus());
         }
     }
 
@@ -81,7 +82,7 @@ export class SearchableSelect implements ICustomElementViewModel {
         ev.stopPropagation();
     }
 
-    getOptValue(opt: ISelectOption): any {
+    getOptValue(opt: ISelectOption): string | number | undefined {
         return opt.id !== undefined ? opt.id : opt.value;
     }
 

--- a/src/resources/value-converters/chance.ts
+++ b/src/resources/value-converters/chance.ts
@@ -1,11 +1,17 @@
-﻿export class ChanceValueConverter {
-    toView(affix: any, pool: any[]) {
+﻿interface IChanceItem {
+    PropertyString?: string;
+    Chance?: number;
+    ModChance?: number;
+}
+
+export class ChanceValueConverter {
+    toView(affix: IChanceItem, pool: IChanceItem[]) {
         if (!pool || pool.length === 0) return 0;
         // Filter pool to only include items with PropertyString (actual properties)
         const propertyPool = pool.filter(item => item.PropertyString);
         if (propertyPool.length === 0) return 0;
 
-        const totalChance = propertyPool.reduce((sum, item) => sum + (item.Chance || item.ModChance || 1), 0);
+        const totalChance = propertyPool.reduce((sum: number, item: IChanceItem) => sum + (item.Chance || item.ModChance || 1), 0);
         const specificChance = affix.Chance || affix.ModChance || 1;
         const chancePercent = (specificChance / totalChance) * 100;
         // Format to 1 decimal place if not an integer, otherwise no decimals

--- a/src/resources/value-converters/entries.ts
+++ b/src/resources/value-converters/entries.ts
@@ -1,5 +1,5 @@
 ﻿export class EntriesValueConverter {
-    toView(obj: any) {
+    toView(obj: Record<string, unknown> | null | undefined) {
         if (!obj) return [];
         return Object.entries(obj);
     }

--- a/src/resources/value-converters/sort-properties.ts
+++ b/src/resources/value-converters/sort-properties.ts
@@ -1,16 +1,24 @@
-﻿export class SortPropertiesValueConverter {
-    toView(properties: any[]) {
+﻿interface ISortProperty {
+    PropertyString?: string;
+    pickmode?: number;
+    PickMode?: number;
+    'group-properties'?: Record<string, ISortProperty[]>;
+}
+
+export class SortPropertiesValueConverter {
+    toView(properties: ISortProperty[]) {
         if (!properties || !Array.isArray(properties)) return properties;
 
         return [...properties].sort((a, b) => {
-            const getPriority = (p: any) => {
+            const getPriority = (p: ISortProperty) => {
                 // If it's a group property
                 if (p['group-properties']) {
                     const pools = Object.values(p['group-properties']);
                     if (pools.length > 0) {
-                        const pool = pools[0] as any[];
+                        const pool = pools[0];
                         // Check if it's pickmode 0 (as number or string)
                         const pickMode = p.pickmode ?? (pool[0] ? pool[0].PickMode : undefined);
+                        // eslint-disable-next-line eqeqeq
                         if (pickMode == 0) {
                             return 0; // Pickmode 0 group (high priority)
                         }

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -169,7 +169,7 @@
     }
 
     .peer:disabled ~ .floating-label {
-        @apply bg-gray-900 text-gray-500;
+        @apply bg-transparent text-gray-500;
     }
 
     /* MSO Float compatibility */


### PR DESCRIPTION
Resolves: #52

Adds a searchable text box to item type, item equipment, affix notes, cube notes dropdown menus.
All other elements while they have code changes, do not have user-facing changes.

Linted to fix things introduced by past commits to main.