### PR TITLE
feat(#51): Add All-1H-2H Toggle to Weapon Sorting

### DIFF
--- a/src/pages/affixes/affixes.html
+++ b/src/pages/affixes/affixes.html
@@ -69,7 +69,7 @@
                     </button>
                 </div>
 
-                <div class="w-full lg:w-60" data-help-text="Search across all fields. Attempts exact match. Seperate with '+' for AND match. Seperate with ',' or '|' for OR match. ex. 'fire skill damage+enemy fire' finds items with only both tokens. 'fire skill damage,enemy fire' finds items with either token.">
+                <div class="w-full lg:w-60" data-help-text="Search across all fields. Text is matched as a phrase. Use '+' to require multiple terms (AND). Use ',' or '|' for OR. Prefix with '-' or '!' to exclude a term or phrase. ex. 'fire skill damage' finds the exact phrase. 'fire+cold' finds items with both. 'fire,cold' finds items with either. '-fire' excludes items containing fire. 'damage -fire' finds items with damage but not fire. 'fire skill damage -cold skill damage' finds fire skill damage but excludes cold skill damage.">
                     <div class="flex items-stretch">
                         <div class="trailing-icon flex-1" data-icon="search">
                             <input id="inputsearch" type="text" class="select-base peer pr-12" value.bind="search"

--- a/src/pages/affixes/affixes.ts
+++ b/src/pages/affixes/affixes.ts
@@ -10,6 +10,7 @@ import {
 } from '../../resources/constants';
 import { debounce, IDebouncedFunction } from '../../utilities/debounce';
 import {
+    matchesTokenGroups,
     prependTypeResetOption,
     swapMinMax,
     tokenizeSearch,
@@ -412,7 +413,7 @@ export class Affixes {
                     .filter(Boolean)
                     .join(' ')
                     .toLowerCase();
-                if (!tokens.some((group) => group.every((t) => hay.includes(t))))
+                if (!matchesTokenGroups(hay, tokens))
                     return false;
             }
 

--- a/src/pages/bases/bases.html
+++ b/src/pages/bases/bases.html
@@ -1,4 +1,4 @@
-﻿<template>
+<template>
     <h3 class="text-lg type-text text-center my-4">
         <span class="rarity-text">[N]</span> = Normal <span class="rarity-text">[X]</span> = Exceptional <span
             class="rarity-text">[E]</span> = Elite
@@ -83,7 +83,7 @@
                 </div>
 
                 <div class="w-full lg:w-60"
-                     data-help-text="Search across all fields. Attempts exact match. Seperate with '+' for AND match. Seperate with ',' or '|' for OR match. ex. 'fire skill damage+enemy fire' finds items with only both tokens. 'fire skill damage,enemy fire' finds items with either token.">
+                     data-help-text="Search across all fields. Text is matched as a phrase. Use '+' to require multiple terms (AND). Use ',' or '|' for OR. Prefix with '-' or '!' to exclude a term or phrase. ex. 'fire skill damage' finds the exact phrase. 'fire+cold' finds items with both. 'fire,cold' finds items with either. '-fire' excludes items containing fire. 'damage -fire' finds items with damage but not fire. 'fire skill damage -cold skill damage' finds fire skill damage but excludes cold skill damage.">
                     <div class="flex items-stretch">
                         <div class="trailing-icon flex-1" data-icon="search">
                             <input id="inputsearch" type="text" class="select-base peer pr-12" value.bind="search"

--- a/src/pages/bases/bases.ts
+++ b/src/pages/bases/bases.ts
@@ -416,16 +416,26 @@ export class Bases {
     }
 
     private buildSearchString(i: IBaseItem): string {
-        return [
-            i.Name,
-            i.Type?.Name,
+        const parts: string[] = [
+            i.Name ?? '',
+            i.Type?.Name ?? '',
             i.NormCode ?? '',
             i.UberCode ?? '',
             i.UltraCode ?? '',
-        ]
-            .filter(Boolean)
-            .join(' ')
-            .toLowerCase();
+        ];
+        if (i.DamageString) {
+            if (i.DamageStringPrefix && String(i.DamageStringPrefix).trim() !== '') {
+                parts.push(i.DamageStringPrefix);
+            }
+            parts.push(i.DamageString);
+        }
+        if (Array.isArray(i.DamageTypes)) {
+            for (const d of i.DamageTypes) {
+                parts.push(getDamageTypeStringUtil(d.Type));
+                if (d.DamageString) parts.push(d.DamageString);
+            }
+        }
+        return parts.filter(Boolean).join(' ').toLowerCase();
     }
 
     groupedProperties(item: IBaseItem) {

--- a/src/pages/bases/bases.ts
+++ b/src/pages/bases/bases.ts
@@ -11,7 +11,7 @@ import {
     getDamageTypeString as getDamageTypeStringUtil,
     IDamageType,
 } from '../../utilities/damage-types';
-import { prependTypeResetOption, tokenizeSearch } from '../../utilities/filter-helpers';
+import { matchesTokenGroups, prependTypeResetOption, tokenizeSearch } from '../../utilities/filter-helpers';
 import { isBlankOrInvalid, syncParamsToUrl } from '../../utilities/url-sanitize';
 import armorsJson from '../item-jsons/armors.json';
 import weaponsJson from '../item-jsons/weapons.json';
@@ -270,9 +270,7 @@ export class Bases {
 
         for (const i of all) {
             const hay = this._searchMap.get(i) || '';
-            const matches = !searchTokens.length || searchTokens.some((group) =>
-                group.every((t) => hay.includes(t)),
-            );
+            const matches = !searchTokens.length || matchesTokenGroups(hay, searchTokens);
             if (matches) {
                 primary.push(i);
                 if (i.NormCode) codeSet.add(i.NormCode.toLowerCase());

--- a/src/pages/cube-recipes/cube-recipes.html
+++ b/src/pages/cube-recipes/cube-recipes.html
@@ -40,7 +40,7 @@
                 </div>
 
                 <div class="w-full lg:w-60"
-                     data-help-text="Search across all fields. Attempts exact match. Seperate with '+' for AND match. Seperate with ',' or '|' for OR match. ex. 'fire skill damage+enemy fire' finds items with only both tokens. 'fire skill damage,enemy fire' finds items with either token.">
+                     data-help-text="Search across all fields. Text is matched as a phrase. Use '+' to require multiple terms (AND). Use ',' or '|' for OR. Prefix with '-' or '!' to exclude a term or phrase. ex. 'fire skill damage' finds the exact phrase. 'fire+cold' finds items with both. 'fire,cold' finds items with either. '-fire' excludes items containing fire. 'damage -fire' finds items with damage but not fire. 'fire skill damage -cold skill damage' finds fire skill damage but excludes cold skill damage.">
                     <div class="flex items-stretch">
                         <div class="trailing-icon flex-1" data-icon="search">
                             <input id="inputsearch" type="text" class="select-base peer pr-12" value.bind="search"

--- a/src/pages/cube-recipes/cube-recipes.ts
+++ b/src/pages/cube-recipes/cube-recipes.ts
@@ -1,7 +1,7 @@
 import { bindable, watch } from 'aurelia';
 
 import { debounce, IDebouncedFunction } from '../../utilities/debounce';
-import { tokenizeSearch } from '../../utilities/filter-helpers';
+import { matchesTokenGroups, tokenizeSearch } from '../../utilities/filter-helpers';
 import { isBlankOrInvalid, syncParamsToUrl } from '../../utilities/url-sanitize';
 import v2json from '../item-jsons/cube_recipes_v2.json';
 
@@ -350,7 +350,7 @@ export class CubeRecipes {
                     .filter(Boolean)
                     .join(' ')
                     .toLowerCase();
-                if (!tokens.some((group) => group.every((t) => haystack.includes(t))))
+                if (!matchesTokenGroups(haystack, tokens))
                     continue;
             }
 

--- a/src/pages/grail/grail.html
+++ b/src/pages/grail/grail.html
@@ -186,6 +186,21 @@
             <h4 class="text-lg type-text text-center mb-2">Sort by Average Weapon Damage:</h4>
             <div class="flex flex-wrap justify-center items-start gap-2">
 
+                <div class="w-full lg:w-auto lg:min-w-45" data-help-text="Toggle weapon type filter: All → 1H Only → 2H Only → All.">
+                    <div class="flex items-stretch">
+                        <div class="relative flex-1">
+                            <button id="handfilter" class="vanilla-button" type="button" click.trigger="toggleHandFilter()"
+                                    aria-pressed.bind="handFilterMode !== 'all'">
+                                Type: ${getHandFilterLabel(handFilterMode)}
+                            </button>
+                        </div>
+                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="handfilter">
+                            <span class="mso">info</span>
+                            <span class="sr-only">More info about Type filter</span>
+                        </button>
+                    </div>
+                </div>
+
                 <div repeat.for="opt of weaponSortOptions" class="w-full lg:w-auto lg:min-w-45" data-help-text.bind="opt.help">
                     <div class="flex items-stretch">
                         <div class="relative flex-1">

--- a/src/pages/grail/grail.html
+++ b/src/pages/grail/grail.html
@@ -128,7 +128,7 @@
                     </div>
                 </div>
 
-                <div class="w-full lg:w-60" data-help-text="Search across all fields. Attempts exact match. Seperate with '+' for AND match. Seperate with ',' or '|' for OR match. ex. 'fire skill damage+enemy fire' finds items with only both tokens. 'fire skill damage,enemy fire' finds items with either token.">
+                <div class="w-full lg:w-60" data-help-text="Search across all fields. Text is matched as a phrase. Use '+' to require multiple terms (AND). Use ',' or '|' for OR. Prefix with '-' or '!' to exclude a term or phrase. ex. 'fire skill damage' finds the exact phrase. 'fire+cold' finds items with both. 'fire,cold' finds items with either. '-fire' excludes items containing fire. 'damage -fire' finds items with damage but not fire. 'fire skill damage -cold skill damage' finds fire skill damage but excludes cold skill damage.">
                     <div class="flex items-stretch">
                         <div class="trailing-icon flex-1" data-icon="search">
                             <input id="inputsearch" type="text" class="select-base peer pr-12" value.bind="search"

--- a/src/pages/grail/grail.html
+++ b/src/pages/grail/grail.html
@@ -186,17 +186,17 @@
             <h4 class="text-lg type-text text-center mb-2">Sort by Average Weapon Damage:</h4>
             <div class="flex flex-wrap justify-center items-start gap-2">
 
-                <div class="w-full lg:w-auto lg:min-w-45" data-help-text="Toggle weapon type filter: All → 1H Only → 2H Only → All.">
+                <div class="w-full lg:w-auto lg:min-w-45" data-help-text="Filter weapon type: All, 1H Only, or 2H Only.">
                     <div class="flex items-stretch">
                         <div class="relative flex-1">
-                            <button id="handfilter" class="vanilla-button" type="button" click.trigger="toggleHandFilter()"
-                                    aria-pressed.bind="handFilterMode !== 'all'">
-                                Type: ${getHandFilterLabel(handFilterMode)}
-                            </button>
+                            <select id="handfilter" class="select-base peer" value.bind="handFilterMode">
+                                <option repeat.for="opt of handFilterOptions" value.bind="opt.value">${opt.label}</option>
+                            </select>
+                            <label for="handfilter" class="floating-label">Weapon Type</label>
                         </div>
                         <button type="button" class="m-info-button" aria-expanded="false" data-info-for="handfilter">
                             <span class="mso">info</span>
-                            <span class="sr-only">More info about Type filter</span>
+                            <span class="sr-only">More info about Weapon Type filter</span>
                         </button>
                     </div>
                 </div>

--- a/src/pages/grail/grail.html
+++ b/src/pages/grail/grail.html
@@ -186,13 +186,13 @@
             <h4 class="text-lg type-text text-center mb-2">Sort by Average Weapon Damage:</h4>
             <div class="flex flex-wrap justify-center items-start gap-2">
 
-                <div class="w-full lg:w-auto lg:min-w-45" data-help-text="Filter weapon type: All, 1H Only, or 2H Only.">
+                <div class="w-full lg:w-auto lg:min-w-55" data-help-text="Filter weapon type: -, 1H Only, or 2H Only.">
                     <div class="flex items-stretch">
                         <div class="relative flex-1">
                             <select id="handfilter" class="select-base peer" value.bind="handFilterMode">
                                 <option repeat.for="opt of handFilterOptions" value.bind="opt.value">${opt.label}</option>
                             </select>
-                            <label for="handfilter" class="floating-label">Weapon Type</label>
+                            <label for="handfilter" class="floating-label">Select Weapon Type</label>
                         </div>
                         <button type="button" class="m-info-button" aria-expanded="false" data-info-for="handfilter">
                             <span class="mso">info</span>

--- a/src/pages/grail/grail.ts
+++ b/src/pages/grail/grail.ts
@@ -131,7 +131,7 @@ export class Grail {
     // When true, hide items where Vanilla === 'Y'
     @bindable hideVanilla: boolean = false;
     @bindable weaponSortMode: WeaponSortMode = 'none';
-    @bindable handFilterMode: HandFilterMode = 'all';
+    @bindable handFilterMode: HandFilterMode = '';
 
     // Helper to check if current type is weapon
     get isWeaponType(): boolean {
@@ -514,7 +514,7 @@ export class Grail {
         this.showFoundItems = false;
         this.hideVanilla = false;
         this.weaponSortMode = 'none';
-        this.handFilterMode = 'all';
+        this.handFilterMode = '';
 
         // Rebuild options list for the current category and refresh
         this.rebuildTypeOptions();
@@ -526,7 +526,7 @@ export class Grail {
     // Reset only the weapon sorting mode
     resetSort() {
         this.weaponSortMode = 'none';
-        this.handFilterMode = 'all';
+        this.handFilterMode = '';
         if (this._debouncedApplyFilters) this._debouncedApplyFilters();
     }
 
@@ -580,7 +580,7 @@ export class Grail {
             });
             this.filteredUniques = result;
             // Hand filter (1H / 2H):
-            if (this.handFilterMode !== 'all') {
+            if (this.handFilterMode) {
                 this.filteredUniques = this.filteredUniques.filter((u) =>
                     passesHandFilter(u?.Equipment?.DamageTypes, this.handFilterMode),
                 );
@@ -618,7 +618,7 @@ export class Grail {
             });
             this.filteredSetItems = result;
             // Hand filter (1H / 2H):
-            if (this.handFilterMode !== 'all') {
+            if (this.handFilterMode) {
                 this.filteredSetItems = this.filteredSetItems.filter((si) =>
                     passesHandFilter(si?.Equipment?.DamageTypes, this.handFilterMode),
                 );

--- a/src/pages/grail/grail.ts
+++ b/src/pages/grail/grail.ts
@@ -17,6 +17,7 @@ import { debounce, IDebouncedFunction } from '../../utilities/debounce';
 import {
     isVanillaItem,
     prependTypeResetOption,
+    type SearchToken,
     tokenizeSearch,
 } from '../../utilities/filter-helpers';
 import {
@@ -840,18 +841,18 @@ export class Grail {
     }
 
     // Checks that the search query matches the item's searchable string.
-    // queryGroups is an OR-list of AND-groups (string[][]).
+    // queryGroups is an OR-list of AND-groups (SearchToken[][]).
     // An item matches if at least one OR-group matches.
-    // An OR-group matches if all its AND-terms are present as substrings in the searchable string.
+    // An OR-group matches if all its non-negated terms are present and all negated terms are absent.
     private tokensPartiallyMatch(
         searchString: string | undefined,
-        queryGroups: string[][],
+        queryGroups: SearchToken[][],
     ): boolean {
         if (!queryGroups.length) return true;
         if (!searchString) return false;
 
         return queryGroups.some((group) => {
-            return group.every((term) => searchString.includes(term));
+            return group.every((t) => (t.negated ? !searchString.includes(t.term) : searchString.includes(t.term)));
         });
     }
 

--- a/src/pages/grail/grail.ts
+++ b/src/pages/grail/grail.ts
@@ -554,39 +554,34 @@ export class Grail {
                 : null;
 
         if (this.selectedCategory === 'uniques') {
+            const selectedClassLower = this.selectedClass ? String(this.selectedClass).toLowerCase() : '';
+            const hasSearch = searchTokens.length > 0;
+            const checkFound = this.showFoundItems;
+            const checkVanilla = this.hideVanilla;
+
             const result = this.uniques.filter((unique) => {
-                const okClass =
-                    !this.selectedClass ||
-                    String(unique?.Equipment?.RequiredClass || '')
-                        .toLowerCase()
-                        .includes(String(this.selectedClass).toLowerCase());
-                const okType =
-                    !selectedTypeSet ||
-                    selectedTypeSet.has(
-                        getChainForTypeNameReadonly(unique?.Type ?? '')[0] || (unique?.Type ?? ''),
-                    );
-                const okEquip =
-                    !this.selectedEquipmentName ||
-                    String(unique?.Equipment?.Name || '') === this.selectedEquipmentName;
-                const okVanilla = !this.hideVanilla || !isVanillaItem(unique?.Vanilla);
-                const okSearch = this.tokensPartiallyMatch(
-                    this._uniqueSearchString.get(this.getUniqueKey(unique)),
-                    searchTokens,
-                );
-                const notGrabber = !String(unique?.Name || '')
-                    .toLowerCase()
-                    .includes('grabber');
+                // Cheap checks first
+                if (String(unique?.Name || '').toLowerCase().includes('grabber')) return false;
+                if (checkVanilla && isVanillaItem(unique?.Vanilla)) return false;
+
+                if (selectedClassLower) {
+                    const req = String(unique?.Equipment?.RequiredClass || '').toLowerCase();
+                    if (!req.includes(selectedClassLower)) return false;
+                }
+                if (selectedTypeSet) {
+                    const base = getChainForTypeNameReadonly(unique?.Type ?? '')[0] || (unique?.Type ?? '');
+                    if (!selectedTypeSet.has(base)) return false;
+                }
+                if (this.selectedEquipmentName &&
+                    String(unique?.Equipment?.Name || '') !== this.selectedEquipmentName) return false;
+
                 const key = this.getUniqueKey(unique);
-                const okFound = !this.showFoundItems || !this.foundUniques[key];
-                return (
-                    okClass &&
-                    okType &&
-                    okEquip &&
-                    okVanilla &&
-                    okSearch &&
-                    notGrabber &&
-                    okFound
-                );
+                if (checkFound && this.foundUniques[key]) return false;
+
+                // Expensive search check last
+                if (hasSearch && !this.tokensPartiallyMatch(this._uniqueSearchString.get(key), searchTokens)) return false;
+
+                return true;
             });
             this.filteredUniques = result;
             // Hand filter (1H / 2H):
@@ -600,28 +595,31 @@ export class Grail {
             }
             this.displayedCount = this.filteredUniques.length;
         } else if (this.selectedCategory === 'sets') {
+            const selectedClassLower = this.selectedClass ? String(this.selectedClass).toLowerCase() : '';
+            const hasSearch = searchTokens.length > 0;
+            const checkFound = this.showFoundItems;
+            const checkVanilla = this.hideVanilla;
+
             const result = this.allSetItems.filter((item) => {
-                const okClass =
-                    !this.selectedClass ||
-                    String(item?.Equipment?.RequiredClass || '')
-                        .toLowerCase()
-                        .includes(String(this.selectedClass).toLowerCase());
-                const okType =
-                    !selectedTypeSet ||
-                    selectedTypeSet.has(
-                        getChainForTypeNameReadonly(item?.Type ?? '')[0] || (item?.Type ?? ''),
-                    );
-                const okEquip =
-                    !this.selectedEquipmentName ||
-                    String(item?.Equipment?.Name || '') === this.selectedEquipmentName;
-                const okVanilla = !this.hideVanilla || !isVanillaItem(item?.Vanilla);
-                const okSearch = this.tokensPartiallyMatch(
-                    this._setItemSearchString.get(this.getSetItemKey(item)),
-                    searchTokens,
-                );
+                if (checkVanilla && isVanillaItem(item?.Vanilla)) return false;
+
+                if (selectedClassLower) {
+                    const req = String(item?.Equipment?.RequiredClass || '').toLowerCase();
+                    if (!req.includes(selectedClassLower)) return false;
+                }
+                if (selectedTypeSet) {
+                    const base = getChainForTypeNameReadonly(item?.Type ?? '')[0] || (item?.Type ?? '');
+                    if (!selectedTypeSet.has(base)) return false;
+                }
+                if (this.selectedEquipmentName &&
+                    String(item?.Equipment?.Name || '') !== this.selectedEquipmentName) return false;
+
                 const key = this.getSetItemKey(item);
-                const okFound = !this.showFoundItems || !this.foundSets[key];
-                return okClass && okType && okEquip && okVanilla && okSearch && okFound;
+                if (checkFound && this.foundSets[key]) return false;
+
+                if (hasSearch && !this.tokensPartiallyMatch(this._setItemSearchString.get(key), searchTokens)) return false;
+
+                return true;
             });
             this.filteredSetItems = result;
             // Hand filter (1H / 2H):

--- a/src/pages/grail/grail.ts
+++ b/src/pages/grail/grail.ts
@@ -21,12 +21,11 @@ import {
     tokenizeSearch,
 } from '../../utilities/filter-helpers';
 import {
-    getHandFilterLabel,
+    handFilterOptions,
     getSortKeyFromDamageType as getSortKeyFromDamageTypeUtil,
     HandFilterMode,
     passesHandFilter,
     sortItemsByWeaponDamage,
-    toggleHandFilter,
     toggleWeaponSort,
     WeaponSortMode,
     weaponSortOptions,
@@ -151,6 +150,7 @@ export class Grail {
     }
 
     weaponSortOptions = weaponSortOptions;
+    handFilterOptions = handFilterOptions;
 
     // Centralized options list (rebuilt per category based on data present)
     types: ReadonlyArray<IFilterOption> = type_filtering_options.slice();
@@ -400,6 +400,8 @@ export class Grail {
     }
 
     @watch('selectedType')
+    @watch('weaponSortMode')
+    @watch('handFilterMode')
     selectedTypeChanged(): void {
         // Reset equipment selection
         this.selectedEquipmentName = undefined;
@@ -536,13 +538,6 @@ export class Grail {
     getSortKeyFromDamageType(type: number): string | null {
         return getSortKeyFromDamageTypeUtil(type);
     }
-
-    toggleHandFilter() {
-        this.handFilterMode = toggleHandFilter(this.handFilterMode);
-        if (this._debouncedApplyFilters) this._debouncedApplyFilters();
-    }
-
-    getHandFilterLabel = getHandFilterLabel;
 
     updateList() {
         // Filter per category

--- a/src/pages/grail/grail.ts
+++ b/src/pages/grail/grail.ts
@@ -20,8 +20,12 @@ import {
     tokenizeSearch,
 } from '../../utilities/filter-helpers';
 import {
+    getHandFilterLabel,
     getSortKeyFromDamageType as getSortKeyFromDamageTypeUtil,
+    HandFilterMode,
+    passesHandFilter,
     sortItemsByWeaponDamage,
+    toggleHandFilter,
     toggleWeaponSort,
     WeaponSortMode,
     weaponSortOptions,
@@ -127,6 +131,7 @@ export class Grail {
     // When true, hide items where Vanilla === 'Y'
     @bindable hideVanilla: boolean = false;
     @bindable weaponSortMode: WeaponSortMode = 'none';
+    @bindable handFilterMode: HandFilterMode = 'all';
 
     // Helper to check if current type is weapon
     get isWeaponType(): boolean {
@@ -506,6 +511,7 @@ export class Grail {
         this.showFoundItems = false;
         this.hideVanilla = false;
         this.weaponSortMode = 'none';
+        this.handFilterMode = 'all';
 
         // Rebuild options list for the current category and refresh
         this.rebuildTypeOptions();
@@ -517,6 +523,7 @@ export class Grail {
     // Reset only the weapon sorting mode
     resetSort() {
         this.weaponSortMode = 'none';
+        this.handFilterMode = 'all';
         if (this._debouncedApplyFilters) this._debouncedApplyFilters();
     }
 
@@ -528,6 +535,13 @@ export class Grail {
     getSortKeyFromDamageType(type: number): string | null {
         return getSortKeyFromDamageTypeUtil(type);
     }
+
+    toggleHandFilter() {
+        this.handFilterMode = toggleHandFilter(this.handFilterMode);
+        if (this._debouncedApplyFilters) this._debouncedApplyFilters();
+    }
+
+    getHandFilterLabel = getHandFilterLabel;
 
     updateList() {
         // Filter per category
@@ -574,6 +588,12 @@ export class Grail {
                 );
             });
             this.filteredUniques = result;
+            // Hand filter (1H / 2H):
+            if (this.handFilterMode !== 'all') {
+                this.filteredUniques = this.filteredUniques.filter((u) =>
+                    passesHandFilter(u?.Equipment?.DamageTypes, this.handFilterMode),
+                );
+            }
             if (this.isWeaponType && this.weaponSortMode !== 'none') {
                 this.filteredUniques = sortItemsByWeaponDamage(this.filteredUniques, this.weaponSortMode);
             }
@@ -603,6 +623,12 @@ export class Grail {
                 return okClass && okType && okEquip && okVanilla && okSearch && okFound;
             });
             this.filteredSetItems = result;
+            // Hand filter (1H / 2H):
+            if (this.handFilterMode !== 'all') {
+                this.filteredSetItems = this.filteredSetItems.filter((si) =>
+                    passesHandFilter(si?.Equipment?.DamageTypes, this.handFilterMode),
+                );
+            }
             if (this.isWeaponType && this.weaponSortMode !== 'none') {
                 this.filteredSetItems = sortItemsByWeaponDamage(this.filteredSetItems, this.weaponSortMode);
             }

--- a/src/pages/grail/grail.ts
+++ b/src/pages/grail/grail.ts
@@ -731,6 +731,13 @@ export class Grail {
                 }
             }
         }
+        // Damage lines
+        if (Array.isArray(u?.Equipment?.DamageTypes)) {
+            for (const d of u.Equipment.DamageTypes) {
+                parts.push(getDamageTypeStringUtil(d.Type));
+                if (d.DamageString) parts.push(d.DamageString);
+            }
+        }
         // Type chain
         parts.push(this.searchStringFromTypeChain(u?.Type));
         return this.buildSearchableString(parts);
@@ -757,6 +764,13 @@ export class Grail {
         if (Array.isArray(it?.SetPropertiesString)) {
             for (const s of it.SetPropertiesString) {
                 if (s) parts.push(String(s));
+            }
+        }
+        // Damage lines
+        if (Array.isArray(it?.Equipment?.DamageTypes)) {
+            for (const d of it.Equipment.DamageTypes) {
+                parts.push(getDamageTypeStringUtil(d.Type));
+                if (d.DamageString) parts.push(d.DamageString);
             }
         }
         parts.push(this.searchStringFromTypeChain(it?.Type));

--- a/src/pages/runewords/runewords.html
+++ b/src/pages/runewords/runewords.html
@@ -63,7 +63,7 @@
                 </div>
 
                 <div class="w-full lg:w-60"
-                     data-help-text="Search across all fields. Attempts exact match. Seperate with '+' for AND match. Seperate with ',' or '|' for OR match. ex. 'fire skill damage+enemy fire' finds items with only both tokens. 'fire skill damage,enemy fire' finds items with either token.">
+                     data-help-text="Search across all fields. Text is matched as a phrase. Use '+' to require multiple terms (AND). Use ',' or '|' for OR. Prefix with '-' or '!' to exclude a term or phrase. ex. 'fire skill damage' finds the exact phrase. 'fire+cold' finds items with both. 'fire,cold' finds items with either. '-fire' excludes items containing fire. 'damage -fire' finds items with damage but not fire. 'fire skill damage -cold skill damage' finds fire skill damage but excludes cold skill damage.">
                     <div class="flex items-stretch">
                         <div class="trailing-icon flex-1" data-icon="search">
                             <input id="inputsearch" type="text" class="select-base peer pr-12" value.bind="search"

--- a/src/pages/runewords/runewords.ts
+++ b/src/pages/runewords/runewords.ts
@@ -7,7 +7,7 @@ import {
     type_filtering_options,
 } from '../../resources/constants';
 import { debounce, IDebouncedFunction } from '../../utilities/debounce';
-import { prependTypeResetOption, tokenizeSearch } from '../../utilities/filter-helpers';
+import { matchesTokenGroups, prependTypeResetOption, tokenizeSearch } from '../../utilities/filter-helpers';
 import { isBlankOrInvalid, syncParamsToUrl } from '../../utilities/url-sanitize';
 import json from '../item-jsons/runewords.json';
 
@@ -301,7 +301,7 @@ export class Runewords {
             // 4. Text search
             if (searchTokens.length > 0) {
                 const hay = this._searchStrings.get(rw) || '';
-                if (!searchTokens.some((group) => group.every((t) => hay.includes(t)))) {
+                if (!matchesTokenGroups(hay, searchTokens)) {
                     return false;
                 }
             }

--- a/src/pages/sets/sets.html
+++ b/src/pages/sets/sets.html
@@ -123,17 +123,17 @@
             <h4 class="text-lg type-text text-center mb-2">Sort by Average Weapon Damage:</h4>
             <div class="flex flex-wrap justify-center items-start gap-2">
 
-                <div class="w-full lg:w-auto lg:min-w-45" data-help-text="Toggle weapon type filter: All → 1H Only → 2H Only → All.">
+                <div class="w-full lg:w-auto lg:min-w-45" data-help-text="Filter weapon type: All, 1H Only, or 2H Only.">
                     <div class="flex items-stretch">
                         <div class="relative flex-1">
-                            <button id="handfilter" class="vanilla-button" type="button" click.trigger="toggleHandFilter()"
-                                    aria-pressed.bind="handFilterMode !== 'all'">
-                                Type: ${getHandFilterLabel(handFilterMode)}
-                            </button>
+                            <select id="handfilter" class="select-base peer" value.bind="handFilterMode">
+                                <option repeat.for="opt of handFilterOptions" value.bind="opt.value">${opt.label}</option>
+                            </select>
+                            <label for="handfilter" class="floating-label">Weapon Type</label>
                         </div>
                         <button type="button" class="m-info-button" aria-expanded="false" data-info-for="handfilter">
                             <span class="mso">info</span>
-                            <span class="sr-only">More info about Type filter</span>
+                            <span class="sr-only">More info about Weapon Type filter</span>
                         </button>
                     </div>
                 </div>

--- a/src/pages/sets/sets.html
+++ b/src/pages/sets/sets.html
@@ -63,7 +63,7 @@
                 </div>
 
                 <div class="w-full lg:w-60"
-                     data-help-text="Search across all fields, sets match as full set if one is found. Uses (space) as an 'AND' modifier. ex: Typing sorc skill mana will return items with only all 3 words.">
+                     data-help-text="Search across all fields, sets match as full set if one is found. Text is matched as a phrase. Use '+' to require multiple terms (AND). Use ',' or '|' for OR. Prefix with '-' or '!' to exclude a term or phrase. ex: 'sorc skill mana' finds the exact phrase. 'fire+cold' finds items with both. '-fire' excludes items containing fire. 'damage -fire' finds items with damage but not fire. 'fire skill damage -cold skill damage' finds fire skill damage but excludes cold skill damage.">
                     <div class="flex items-stretch">
                         <div class="trailing-icon flex-1" data-icon="search">
                             <input id="inputsearch" type="text" class="select-base peer pr-12" value.bind="search"

--- a/src/pages/sets/sets.html
+++ b/src/pages/sets/sets.html
@@ -123,6 +123,21 @@
             <h4 class="text-lg type-text text-center mb-2">Sort by Average Weapon Damage:</h4>
             <div class="flex flex-wrap justify-center items-start gap-2">
 
+                <div class="w-full lg:w-auto lg:min-w-45" data-help-text="Toggle weapon type filter: All → 1H Only → 2H Only → All.">
+                    <div class="flex items-stretch">
+                        <div class="relative flex-1">
+                            <button id="handfilter" class="vanilla-button" type="button" click.trigger="toggleHandFilter()"
+                                    aria-pressed.bind="handFilterMode !== 'all'">
+                                Type: ${getHandFilterLabel(handFilterMode)}
+                            </button>
+                        </div>
+                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="handfilter">
+                            <span class="mso">info</span>
+                            <span class="sr-only">More info about Type filter</span>
+                        </button>
+                    </div>
+                </div>
+
                 <div repeat.for="opt of weaponSortOptions" class="w-full lg:w-auto lg:min-w-45" data-help-text.bind="opt.help">
                     <div class="flex items-stretch">
                         <div class="relative flex-1">

--- a/src/pages/sets/sets.html
+++ b/src/pages/sets/sets.html
@@ -123,7 +123,7 @@
             <h4 class="text-lg type-text text-center mb-2">Sort by Average Weapon Damage:</h4>
             <div class="flex flex-wrap justify-center items-start gap-2">
 
-                <div class="w-full lg:w-auto lg:min-w-45" data-help-text="Filter weapon type: All, 1H Only, or 2H Only.">
+                <div class="w-full lg:w-auto lg:min-w-55" data-help-text="Filter weapon type: -, 1H Only, or 2H Only.">
                     <div class="flex items-stretch">
                         <div class="relative flex-1">
                             <select id="handfilter" class="select-base peer" value.bind="handFilterMode">

--- a/src/pages/sets/sets.ts
+++ b/src/pages/sets/sets.ts
@@ -18,6 +18,7 @@ import {
 import { debounce, IDebouncedFunction } from '../../utilities/debounce';
 import {
     isVanillaItem,
+    matchesTokenGroups,
     prependTypeResetOption,
     tokenizeSearch,
 } from '../../utilities/filter-helpers';
@@ -244,7 +245,7 @@ export class Sets {
 
                 // 5. Search filter
                 if (searchTokens.length > 0) {
-                    if (!searchTokens.some((group) => group.every((t) => hay.includes(t)))) {
+                    if (!matchesTokenGroups(hay, searchTokens)) {
                         return false;
                     }
                 }

--- a/src/pages/sets/sets.ts
+++ b/src/pages/sets/sets.ts
@@ -23,11 +23,10 @@ import {
     tokenizeSearch,
 } from '../../utilities/filter-helpers';
 import {
-    getHandFilterLabel,
+    handFilterOptions,
     getSortKeyFromDamageType as getSortKeyFromDamageTypeUtil,
     HandFilterMode,
     passesHandFilter,
-    toggleHandFilter,
     toggleWeaponSort,
     WeaponSortMode,
     weaponSortOptions,
@@ -78,6 +77,7 @@ export class Sets {
     }
 
     weaponSortOptions = weaponSortOptions;
+    handFilterOptions = handFilterOptions;
 
     // Build options and hydrate from URL BEFORE controls render
     binding(): void {
@@ -174,6 +174,7 @@ export class Sets {
     @watch('selectedClass')
     @watch('hideVanilla')
     @watch('weaponSortMode')
+    @watch('handFilterMode')
     handleFilterChanged(): void {
         this.updateList();
         if (this._debouncedUpdateUrl) this._debouncedUpdateUrl();
@@ -413,11 +414,4 @@ export class Sets {
     getSortKeyFromDamageType(type: number): string | null {
         return getSortKeyFromDamageTypeUtil(type);
     }
-
-    toggleHandFilter() {
-        this.handFilterMode = toggleHandFilter(this.handFilterMode);
-        this.updateList();
-    }
-
-    getHandFilterLabel = getHandFilterLabel;
 }

--- a/src/pages/sets/sets.ts
+++ b/src/pages/sets/sets.ts
@@ -22,7 +22,11 @@ import {
     tokenizeSearch,
 } from '../../utilities/filter-helpers';
 import {
+    getHandFilterLabel,
     getSortKeyFromDamageType as getSortKeyFromDamageTypeUtil,
+    HandFilterMode,
+    passesHandFilter,
+    toggleHandFilter,
     toggleWeaponSort,
     WeaponSortMode,
     weaponSortOptions,
@@ -44,6 +48,7 @@ export class Sets {
     // When true, exclude items where Vanilla === 'Y'
     @bindable hideVanilla: boolean = false;
     @bindable weaponSortMode: WeaponSortMode = 'none';
+    @bindable handFilterMode: HandFilterMode = 'all';
 
     private _debouncedSearchItem!: IDebouncedFunction;
     private _debouncedUpdateUrl!: IDebouncedFunction;
@@ -247,6 +252,15 @@ export class Sets {
                 return true;
             });
 
+            // Hand filter (1H / 2H):
+            if (this.handFilterMode !== 'all') {
+                this.sets = this.sets.filter((set: ISetData) =>
+                    (set.SetItems ?? []).some((si) =>
+                        passesHandFilter(si?.Equipment?.DamageTypes, this.handFilterMode),
+                    ),
+                );
+            }
+
             // Main sorting logic:
             if (this.isWeaponType && this.weaponSortMode !== 'none') {
                 const isAsc = this.weaponSortMode.includes('ascending');
@@ -374,6 +388,7 @@ export class Sets {
         this.hideVanilla = false;
         this.equipmentNames = [{ value: '', label: '-' }];
         this.weaponSortMode = 'none';
+        this.handFilterMode = 'all';
 
         this.updateList();
         this.updateUrl();
@@ -382,6 +397,7 @@ export class Sets {
     // Reset only the weapon sorting mode
     resetSort() {
         this.weaponSortMode = 'none';
+        this.handFilterMode = 'all';
     }
 
     toggleSort(type: string) {
@@ -391,4 +407,11 @@ export class Sets {
     getSortKeyFromDamageType(type: number): string | null {
         return getSortKeyFromDamageTypeUtil(type);
     }
+
+    toggleHandFilter() {
+        this.handFilterMode = toggleHandFilter(this.handFilterMode);
+        this.updateList();
+    }
+
+    getHandFilterLabel = getHandFilterLabel;
 }

--- a/src/pages/sets/sets.ts
+++ b/src/pages/sets/sets.ts
@@ -330,6 +330,12 @@ export class Sets {
             for (const s of si?.SetPropertiesString || []) {
                 if (s) parts.push(String(s));
             }
+            if (Array.isArray(si?.Equipment?.DamageTypes)) {
+                for (const d of si.Equipment.DamageTypes) {
+                    parts.push(getDamageTypeStringUtil(d.Type));
+                    if (d.DamageString) parts.push(d.DamageString);
+                }
+            }
         }
         return parts.filter(Boolean).join(' ').toLowerCase();
     }

--- a/src/pages/sets/sets.ts
+++ b/src/pages/sets/sets.ts
@@ -262,34 +262,33 @@ export class Sets {
                 );
             }
 
-            // Main sorting logic:
+            // Main sorting logic — precompute sort keys to avoid per-comparison work:
             if (this.isWeaponType && this.weaponSortMode !== 'none') {
                 const isAsc = this.weaponSortMode.includes('ascending');
                 const mode = this.weaponSortMode;
-                this.sets = this.sets.slice().sort((a, b) => {
-                    const getBestDam = (set: ISetData) => {
-                        let maxV = 0;
-                        for (const item of set.SetItems || []) {
-                            let v = 0;
-                            if (mode.includes('1h-phys'))
-                                v = getWeaponPhysDamValue(item as unknown as IUniqueItem, [3, 0]);
-                            else if (mode.includes('2h-phys'))
-                                v = getWeaponPhysDamValue(item as unknown as IUniqueItem, 1);
-                            else if (mode.includes('throw-phys'))
-                                v = getWeaponPhysDamValue(item as unknown as IUniqueItem, 2);
-                            else if (mode.includes('non-phys'))
-                                v = getWeaponNonPhysDamValue(item as unknown as IUniqueItem);
-                            if (v > maxV) maxV = v;
-                        }
-                        return maxV;
-                    };
-                    const vA = getBestDam(a);
-                    const vB = getBestDam(b);
-
-                    if (vA === 0 && vB !== 0) return 1;
-                    if (vA !== 0 && vB === 0) return -1;
-                    return isAsc ? vA - vB : vB - vA;
+                const getBestDam = (set: ISetData): number => {
+                    let maxV = 0;
+                    for (const item of set.SetItems || []) {
+                        let v = 0;
+                        if (mode.includes('1h-phys'))
+                            v = getWeaponPhysDamValue(item as unknown as IUniqueItem, [3, 0]);
+                        else if (mode.includes('2h-phys'))
+                            v = getWeaponPhysDamValue(item as unknown as IUniqueItem, 1);
+                        else if (mode.includes('throw-phys'))
+                            v = getWeaponPhysDamValue(item as unknown as IUniqueItem, 2);
+                        else if (mode.includes('non-phys'))
+                            v = getWeaponNonPhysDamValue(item as unknown as IUniqueItem);
+                        if (v > maxV) maxV = v;
+                    }
+                    return maxV;
+                };
+                const decorated = this.sets.map((set) => ({ set, val: getBestDam(set) }));
+                decorated.sort((a, b) => {
+                    if (a.val === 0 && b.val !== 0) return 1;
+                    if (a.val !== 0 && b.val === 0) return -1;
+                    return isAsc ? a.val - b.val : b.val - a.val;
                 });
+                this.sets = decorated.map((d) => d.set);
             }
         } catch (e) {
             console.error(e);

--- a/src/pages/sets/sets.ts
+++ b/src/pages/sets/sets.ts
@@ -48,7 +48,7 @@ export class Sets {
     // When true, exclude items where Vanilla === 'Y'
     @bindable hideVanilla: boolean = false;
     @bindable weaponSortMode: WeaponSortMode = 'none';
-    @bindable handFilterMode: HandFilterMode = 'all';
+    @bindable handFilterMode: HandFilterMode = '';
 
     private _debouncedSearchItem!: IDebouncedFunction;
     private _debouncedUpdateUrl!: IDebouncedFunction;
@@ -255,7 +255,7 @@ export class Sets {
             });
 
             // Hand filter (1H / 2H):
-            if (this.handFilterMode !== 'all') {
+            if (this.handFilterMode) {
                 this.sets = this.sets.filter((set: ISetData) =>
                     (set.SetItems ?? []).some((si) =>
                         passesHandFilter(si?.Equipment?.DamageTypes, this.handFilterMode),
@@ -395,7 +395,7 @@ export class Sets {
         this.hideVanilla = false;
         this.equipmentNames = [{ value: '', label: '-' }];
         this.weaponSortMode = 'none';
-        this.handFilterMode = 'all';
+        this.handFilterMode = '';
 
         this.updateList();
         this.updateUrl();
@@ -404,7 +404,7 @@ export class Sets {
     // Reset only the weapon sorting mode
     resetSort() {
         this.weaponSortMode = 'none';
-        this.handFilterMode = 'all';
+        this.handFilterMode = '';
     }
 
     toggleSort(type: string) {

--- a/src/pages/uniques/uniques.html
+++ b/src/pages/uniques/uniques.html
@@ -116,7 +116,7 @@
             <h4 class="text-lg type-text text-center mb-2">Sort by Average Weapon Damage:</h4>
             <div class="flex flex-wrap justify-center items-start gap-2">
 
-                <div class="w-full lg:w-auto lg:min-w-45" data-help-text="Filter weapon type: All, 1H Only, or 2H Only.">
+                <div class="w-full lg:w-auto lg:min-w-55" data-help-text="Filter weapon type: All, 1H Only, or 2H Only.">
                     <div class="flex items-stretch">
                         <div class="relative flex-1">
                             <select id="handfilter" class="select-base peer" value.bind="handFilterMode">

--- a/src/pages/uniques/uniques.html
+++ b/src/pages/uniques/uniques.html
@@ -59,7 +59,7 @@
                     </div>
                 </div>
 
-                <div class="w-full lg:w-60" data-help-text="Search across all fields. Attempts exact match. Seperate with '+' for AND match. Seperate with ',' or '|' for OR match. ex. 'fire skill damage+enemy fire' finds items with only both tokens. 'fire skill damage,enemy fire' finds items with either token.">
+                <div class="w-full lg:w-60" data-help-text="Search across all fields. Text is matched as a phrase. Use '+' to require multiple terms (AND). Use ',' or '|' for OR. Prefix with '-' or '!' to exclude a term or phrase. ex. 'fire skill damage' finds the exact phrase. 'fire+cold' finds items with both. 'fire,cold' finds items with either. '-fire' excludes items containing fire. 'damage -fire' finds items with damage but not fire. 'fire skill damage -cold skill damage' finds fire skill damage but excludes cold skill damage.">
                     <div class="flex items-stretch">
                         <div class="trailing-icon flex-1" data-icon="search">
                             <input id="inputsearch" type="text" class="select-base peer pr-12" value.bind="search" placeholder=" "/>

--- a/src/pages/uniques/uniques.html
+++ b/src/pages/uniques/uniques.html
@@ -116,17 +116,17 @@
             <h4 class="text-lg type-text text-center mb-2">Sort by Average Weapon Damage:</h4>
             <div class="flex flex-wrap justify-center items-start gap-2">
 
-                <div class="w-full lg:w-auto lg:min-w-45" data-help-text="Toggle weapon type filter: All → 1H Only → 2H Only → All.">
+                <div class="w-full lg:w-auto lg:min-w-45" data-help-text="Filter weapon type: All, 1H Only, or 2H Only.">
                     <div class="flex items-stretch">
                         <div class="relative flex-1">
-                            <button id="handfilter" class="vanilla-button" type="button" click.trigger="toggleHandFilter()"
-                                    aria-pressed.bind="handFilterMode !== 'all'">
-                                Type: ${getHandFilterLabel(handFilterMode)}
-                            </button>
+                            <select id="handfilter" class="select-base peer" value.bind="handFilterMode">
+                                <option repeat.for="opt of handFilterOptions" value.bind="opt.value">${opt.label}</option>
+                            </select>
+                            <label for="handfilter" class="floating-label">Weapon Type</label>
                         </div>
                         <button type="button" class="m-info-button" aria-expanded="false" data-info-for="handfilter">
                             <span class="mso">info</span>
-                            <span class="sr-only">More info about Type filter</span>
+                            <span class="sr-only">More info about Weapon Type filter</span>
                         </button>
                     </div>
                 </div>

--- a/src/pages/uniques/uniques.html
+++ b/src/pages/uniques/uniques.html
@@ -116,6 +116,21 @@
             <h4 class="text-lg type-text text-center mb-2">Sort by Average Weapon Damage:</h4>
             <div class="flex flex-wrap justify-center items-start gap-2">
 
+                <div class="w-full lg:w-auto lg:min-w-45" data-help-text="Toggle weapon type filter: All → 1H Only → 2H Only → All.">
+                    <div class="flex items-stretch">
+                        <div class="relative flex-1">
+                            <button id="handfilter" class="vanilla-button" type="button" click.trigger="toggleHandFilter()"
+                                    aria-pressed.bind="handFilterMode !== 'all'">
+                                Type: ${getHandFilterLabel(handFilterMode)}
+                            </button>
+                        </div>
+                        <button type="button" class="m-info-button" aria-expanded="false" data-info-for="handfilter">
+                            <span class="mso">info</span>
+                            <span class="sr-only">More info about Type filter</span>
+                        </button>
+                    </div>
+                </div>
+
                 <div repeat.for="opt of weaponSortOptions" class="w-full lg:w-auto lg:min-w-45" data-help-text.bind="opt.help">
                     <div class="flex items-stretch">
                         <div class="relative flex-1">

--- a/src/pages/uniques/uniques.ts
+++ b/src/pages/uniques/uniques.ts
@@ -320,6 +320,13 @@ export class Uniques {
             });
         }
 
+        if (Array.isArray(unique?.Equipment?.DamageTypes)) {
+            for (const d of unique.Equipment.DamageTypes) {
+                parts.push(getDamageTypeStringUtil(d.Type));
+                if (d.DamageString) parts.push(d.DamageString);
+            }
+        }
+
         return parts.filter(Boolean).join(' ').toLowerCase();
     }
 

--- a/src/pages/uniques/uniques.ts
+++ b/src/pages/uniques/uniques.ts
@@ -20,8 +20,12 @@ import {
     tokenizeSearch,
 } from '../../utilities/filter-helpers';
 import {
+    getHandFilterLabel,
     getSortKeyFromDamageType as getSortKeyFromDamageTypeUtil,
+    HandFilterMode,
+    passesHandFilter,
     sortItemsByWeaponDamage,
+    toggleHandFilter,
     toggleWeaponSort,
     WeaponSortMode,
     weaponSortOptions,
@@ -75,6 +79,7 @@ export class Uniques {
     // Current possible sorting modes
     // TODO: Specific non-physical damage sorting in the future? (e.g.: fire damage)
     @bindable weaponSortMode: WeaponSortMode = 'none';
+    @bindable handFilterMode: HandFilterMode = 'all';
 
     equipmentNames: Array<{ value: string | undefined; label: string }> = [];
 
@@ -282,6 +287,13 @@ export class Uniques {
             return true;
         });
 
+        // Hand filter (1H / 2H):
+        if (this.handFilterMode !== 'all') {
+            this.uniques = this.uniques.filter((u) =>
+                passesHandFilter(u?.Equipment?.DamageTypes, this.handFilterMode),
+            );
+        }
+
         // Main sorting logic:
         if (this.isWeaponType && this.weaponSortMode !== 'none') {
             this.uniques = sortItemsByWeaponDamage(this.uniques, this.weaponSortMode);
@@ -372,6 +384,7 @@ export class Uniques {
     // Reset only the weapon sorting mode
     resetSort() {
         this.weaponSortMode = 'none';
+        this.handFilterMode = 'all';
     }
 
     toggleSort(type: string) {
@@ -381,4 +394,11 @@ export class Uniques {
     getSortKeyFromDamageType(type: number): string | null {
         return getSortKeyFromDamageTypeUtil(type);
     }
+
+    toggleHandFilter() {
+        this.handFilterMode = toggleHandFilter(this.handFilterMode);
+        this.updateList();
+    }
+
+    getHandFilterLabel = getHandFilterLabel;
 }

--- a/src/pages/uniques/uniques.ts
+++ b/src/pages/uniques/uniques.ts
@@ -16,6 +16,7 @@ import {
 import { debounce, IDebouncedFunction } from '../../utilities/debounce';
 import {
     isVanillaItem,
+    matchesTokenGroups,
     prependTypeResetOption,
     tokenizeSearch,
 } from '../../utilities/filter-helpers';
@@ -279,7 +280,7 @@ export class Uniques {
             // 5. Search filter
             if (searchTokens.length > 0) {
                 const hay = this._searchStrings.get(unique) || '';
-                if (!searchTokens.some((group) => group.every((t) => hay.includes(t)))) {
+                if (!matchesTokenGroups(hay, searchTokens)) {
                     return false;
                 }
             }

--- a/src/pages/uniques/uniques.ts
+++ b/src/pages/uniques/uniques.ts
@@ -21,12 +21,11 @@ import {
     tokenizeSearch,
 } from '../../utilities/filter-helpers';
 import {
-    getHandFilterLabel,
+    handFilterOptions,
     getSortKeyFromDamageType as getSortKeyFromDamageTypeUtil,
     HandFilterMode,
     passesHandFilter,
     sortItemsByWeaponDamage,
-    toggleHandFilter,
     toggleWeaponSort,
     WeaponSortMode,
     weaponSortOptions,
@@ -185,6 +184,7 @@ export class Uniques {
     @watch('selectedClass')
     @watch('hideVanilla')
     @watch('weaponSortMode')
+    @watch('handFilterMode')
     handleFilterChanged() {
         this.updateList();
         if (this._debouncedUpdateUrl) this._debouncedUpdateUrl();
@@ -197,6 +197,7 @@ export class Uniques {
     }
 
     weaponSortOptions = weaponSortOptions;
+    handFilterOptions = handFilterOptions;
 
     @watch('selectedType')
     handleTypeChanged() {
@@ -402,11 +403,4 @@ export class Uniques {
     getSortKeyFromDamageType(type: number): string | null {
         return getSortKeyFromDamageTypeUtil(type);
     }
-
-    toggleHandFilter() {
-        this.handFilterMode = toggleHandFilter(this.handFilterMode);
-        this.updateList();
-    }
-
-    getHandFilterLabel = getHandFilterLabel;
 }

--- a/src/pages/uniques/uniques.ts
+++ b/src/pages/uniques/uniques.ts
@@ -79,7 +79,7 @@ export class Uniques {
     // Current possible sorting modes
     // TODO: Specific non-physical damage sorting in the future? (e.g.: fire damage)
     @bindable weaponSortMode: WeaponSortMode = 'none';
-    @bindable handFilterMode: HandFilterMode = 'all';
+    @bindable handFilterMode: HandFilterMode = '';
 
     equipmentNames: Array<{ value: string | undefined; label: string }> = [];
 
@@ -290,7 +290,7 @@ export class Uniques {
         });
 
         // Hand filter (1H / 2H):
-        if (this.handFilterMode !== 'all') {
+        if (this.handFilterMode) {
             this.uniques = this.uniques.filter((u) =>
                 passesHandFilter(u?.Equipment?.DamageTypes, this.handFilterMode),
             );
@@ -385,6 +385,7 @@ export class Uniques {
         this.selectedEquipmentName = undefined;
         this.equipmentNames = [{ value: '', label: '-' }];
         this.weaponSortMode = 'none';
+        this.handFilterMode = '';
 
         this.updateList();
         this.updateUrl();
@@ -393,7 +394,7 @@ export class Uniques {
     // Reset only the weapon sorting mode
     resetSort() {
         this.weaponSortMode = 'none';
-        this.handFilterMode = 'all';
+        this.handFilterMode = '';
     }
 
     toggleSort(type: string) {

--- a/src/utilities/filter-helpers.ts
+++ b/src/utilities/filter-helpers.ts
@@ -60,20 +60,53 @@ export function swapMinMax<T extends number | undefined>(
     return [min, max];
 }
 
-/** Tokenize a search string into OR groups (split by ',' or '|') of AND terms (split by '+'). */
-export function tokenizeSearch(input: string | undefined | null): string[][] {
+/** A single search token that may be negated (prefixed with '-' or '!'). */
+export interface SearchToken {
+    term: string;
+    negated: boolean;
+}
+
+/** Tokenize a search string into OR groups (split by ',' or '|') of AND terms (split by '+').
+ *  Within each '+'-delimited segment, phrases starting with '-' or '!' are negated.
+ *  A negation prefix applies to all following words until the next negation or end of segment.
+ *  Example: 'fire skill damage -cold skill damage' → phrase "fire skill damage" + negated "cold skill damage". */
+export function tokenizeSearch(input: string | undefined | null): SearchToken[][] {
     const raw = (input || '').trim().toLowerCase();
     if (!raw) return [];
     // Split by OR operators: ',' or '|'
     return raw
         .split(/[,|]/)
-        .map((group) =>
-            group
-                .split('+')
-                .map((s) => s.trim())
-                .filter(Boolean),
-        )
+        .map((group) => {
+            const tokens: SearchToken[] = [];
+            // Split by '+' for explicit AND
+            for (const segment of group.split('+')) {
+                // Split segment into phrase chunks at negation boundaries.
+                // A negation boundary is a '-' or '!' preceded by whitespace (or at start)
+                // followed by a non-space character.
+                const parts = segment.trim().split(/\s+(?=[-!]\S)/);
+                for (const part of parts) {
+                    const trimmed = part.trim();
+                    if (!trimmed) continue;
+                    // Check if this part starts with a negation prefix
+                    if (/^[-!]\S/.test(trimmed)) {
+                        const term = trimmed.slice(1).trim();
+                        if (term) tokens.push({ term, negated: true });
+                    } else {
+                        tokens.push({ term: trimmed, negated: false });
+                    }
+                }
+            }
+            return tokens;
+        })
         .filter((group) => group.length > 0);
+}
+
+/** Check whether a haystack string matches at least one OR-group of search tokens.
+ *  Each group is an AND-list: every non-negated token must be present and every negated token must be absent. */
+export function matchesTokenGroups(hay: string, groups: SearchToken[][]): boolean {
+    return groups.some((group) =>
+        group.every((t) => (t.negated ? !hay.includes(t.term) : hay.includes(t.term))),
+    );
 }
 
 /** Check if an item is 'vanilla' based on its Vanilla property (usually 'Y'). */

--- a/src/utilities/item-sorting.ts
+++ b/src/utilities/item-sorting.ts
@@ -21,26 +21,26 @@ export function sortItemsByWeaponDamage<T>(items: T[], mode: WeaponSortMode): T[
     if (mode === 'none') return items;
 
     const isAsc = mode.includes('ascending');
-    return items.slice().sort((a, b) => {
-        let vA = 0, vB = 0;
-        if (mode.includes('1h-phys')) {
-            vA = getWeaponPhysDamValue(a as unknown as IUniqueItem, [3, 0]);
-            vB = getWeaponPhysDamValue(b as unknown as IUniqueItem, [3, 0]);
-        } else if (mode.includes('2h-phys')) {
-            vA = getWeaponPhysDamValue(a as unknown as IUniqueItem, 1);
-            vB = getWeaponPhysDamValue(b as unknown as IUniqueItem, 1);
-        } else if (mode.includes('throw-phys')) {
-            vA = getWeaponPhysDamValue(a as unknown as IUniqueItem, 2);
-            vB = getWeaponPhysDamValue(b as unknown as IUniqueItem, 2);
-        } else if (mode.includes('non-phys')) {
-            vA = getWeaponNonPhysDamValue(a as unknown as IUniqueItem);
-            vB = getWeaponNonPhysDamValue(b as unknown as IUniqueItem);
-        }
 
-        if (vA === 0 && vB !== 0) return 1;
-        if (vA !== 0 && vB === 0) return -1;
-        return isAsc ? vA - vB : vB - vA;
+    // Precompute sort keys to avoid repeated DamageTypes lookups during comparisons
+    let getValue: (item: T) => number;
+    if (mode.includes('1h-phys')) {
+        getValue = (item) => getWeaponPhysDamValue(item as unknown as IUniqueItem, [3, 0]);
+    } else if (mode.includes('2h-phys')) {
+        getValue = (item) => getWeaponPhysDamValue(item as unknown as IUniqueItem, 1);
+    } else if (mode.includes('throw-phys')) {
+        getValue = (item) => getWeaponPhysDamValue(item as unknown as IUniqueItem, 2);
+    } else {
+        getValue = (item) => getWeaponNonPhysDamValue(item as unknown as IUniqueItem);
+    }
+
+    const decorated = items.map((item) => ({ item, val: getValue(item) }));
+    decorated.sort((a, b) => {
+        if (a.val === 0 && b.val !== 0) return 1;
+        if (a.val !== 0 && b.val === 0) return -1;
+        return isAsc ? a.val - b.val : b.val - a.val;
     });
+    return decorated.map((d) => d.item);
 }
 
 export function toggleWeaponSort(currentMode: WeaponSortMode, type: string): WeaponSortMode {

--- a/src/utilities/item-sorting.ts
+++ b/src/utilities/item-sorting.ts
@@ -61,10 +61,10 @@ export function getSortKeyFromDamageType(type: number): string | null {
 }
 
 // Hand filter: cycles All → 1H Only → 2H Only → All
-export type HandFilterMode = 'all' | '1h' | '2h';
+export type HandFilterMode = '' | '1h' | '2h';
 
 export const handFilterOptions: { value: HandFilterMode, label: string }[] = [
-    { value: 'all', label: 'All' },
+    { value: '', label: '-' },
     { value: '1h', label: '1H Only' },
     { value: '2h', label: '2H Only' },
 ];
@@ -77,7 +77,7 @@ export const handFilterOptions: { value: HandFilterMode, label: string }[] = [
  * - 'all': keep everything
  */
 export function passesHandFilter(damageTypes: { Type: number }[] | undefined | null, mode: HandFilterMode): boolean {
-    if (mode === 'all') return true;
+    if (!mode) return true;
     const has2H = Array.isArray(damageTypes) && damageTypes.some(d => d.Type === 1);
     if (mode === '1h') return !has2H;
     if (mode === '2h') return has2H;

--- a/src/utilities/item-sorting.ts
+++ b/src/utilities/item-sorting.ts
@@ -63,17 +63,11 @@ export function getSortKeyFromDamageType(type: number): string | null {
 // Hand filter: cycles All → 1H Only → 2H Only → All
 export type HandFilterMode = 'all' | '1h' | '2h';
 
-export function toggleHandFilter(current: HandFilterMode): HandFilterMode {
-    if (current === 'all') return '1h';
-    if (current === '1h') return '2h';
-    return 'all';
-}
-
-export function getHandFilterLabel(mode: HandFilterMode): string {
-    if (mode === '1h') return '1H Only';
-    if (mode === '2h') return '2H Only';
-    return 'All';
-}
+export const handFilterOptions: { value: HandFilterMode, label: string }[] = [
+    { value: 'all', label: 'All' },
+    { value: '1h', label: '1H Only' },
+    { value: '2h', label: '2H Only' },
+];
 
 /**
  * Returns true if the item should be kept based on the hand filter.

--- a/src/utilities/item-sorting.ts
+++ b/src/utilities/item-sorting.ts
@@ -59,3 +59,33 @@ export function getSortKeyFromDamageType(type: number): string | null {
     if (type === 4) return 'non-phys';
     return null;
 }
+
+// Hand filter: cycles All → 1H Only → 2H Only → All
+export type HandFilterMode = 'all' | '1h' | '2h';
+
+export function toggleHandFilter(current: HandFilterMode): HandFilterMode {
+    if (current === 'all') return '1h';
+    if (current === '1h') return '2h';
+    return 'all';
+}
+
+export function getHandFilterLabel(mode: HandFilterMode): string {
+    if (mode === '1h') return '1H Only';
+    if (mode === '2h') return '2H Only';
+    return 'All';
+}
+
+/**
+ * Returns true if the item should be kept based on the hand filter.
+ * Checks DamageTypes on the item (or item.Equipment for uniques).
+ * - '1h': keep only if it does NOT have 2H damage (Type 1)
+ * - '2h': keep only if it DOES have 2H damage (Type 1)
+ * - 'all': keep everything
+ */
+export function passesHandFilter(damageTypes: { Type: number }[] | undefined | null, mode: HandFilterMode): boolean {
+    if (mode === 'all') return true;
+    const has2H = Array.isArray(damageTypes) && damageTypes.some(d => d.Type === 1);
+    if (mode === '1h') return !has2H;
+    if (mode === '2h') return has2H;
+    return true;
+}


### PR DESCRIPTION
Resolves: #51

Adds Type: toggle to weapon sorting panel, defaults to All and resets to All, clickable for 1H only and 2H only.

Add not `-` `!` tokens for searches
Add negation phrase support to searches
>[!NOTE]
>If you wanted to search for an item that contains fire skill damage only you enter `fire skill damage -cold skill damage -lightning skill damage`  It's a baby and can be expanded upon and refined in later updates, current search functionality is unaffected without `-` and `!` use.

Fix some logic errors causing lag on grail page during sorting.