### PR TITLE
fix: life per hit needing an overrride for a missing string translation

### DIFF
--- a/src/lib/i18n.spec.ts
+++ b/src/lib/i18n.spec.ts
@@ -1,0 +1,13 @@
+import { get } from 'svelte/store';
+
+import { describe, expect, it } from 'vitest';
+
+import { i18n, initializeI18n } from './i18n';
+
+describe('keyed line localization', () => {
+  it('renders the numeric range carried by the label-only healperhit string', () => {
+    initializeI18n({ healperhit: 'Life Per Hit' });
+
+    expect(get(i18n).line({ key: 'healperhit', args: [2, 4] })).toBe('2-4 Life Per Hit');
+  });
+});

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -55,6 +55,14 @@ function lookup(s: I18nState, key: string): string {
 }
 
 function prepareSpecial(key: string, template: string, args: ReadonlyArray<TemplateArg>) {
+  // healperhit is a label-only synthetic string in every exported language,
+  // while its keyed catalog line still carries the numeric min/max pair.
+  // Give the shared formatter one numeric slot so it can render that range
+  // without replacing or hard-coding the localized label.
+  if (key === 'healperhit' && args.length > 0) {
+    return { template: `%d ${template}`, args };
+  }
+
   if (key !== 'strSkillRandomFromSkillClass' || args.length < 2) return { template, args };
   const [min, max, ...rest] = args;
   const numeric = typeof min === 'number' && typeof max === 'number'


### PR DESCRIPTION
Closes: #81 